### PR TITLE
feat(fonts): add JetBrains Mono Nerd Font via Home Manager

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -23,6 +23,10 @@
     chezmoi  # Must be in Nix - applies mise.toml config before mise install runs
     mise     # Must be in Nix - installs other dev tools
 
+    # Fonts - installed to ~/Library/Fonts/HomeManager on macOS
+    # See: https://nix-community.github.io/home-manager/options.xhtml#opt-fonts.fontconfig.enable
+    nerd-fonts.jetbrains-mono
+
     # System packages (not available or not suitable for Mise)
     cloudflared
     git
@@ -158,6 +162,9 @@
     
     # ripgrep with path sorting
     rg = "rg --sort path";
+
+    # Font management
+    fonts = "open ~/Library/Fonts/HomeManager";
     
     # Dotfile management
     dot = "cd ~/dotfiles";
@@ -170,4 +177,10 @@
     cme = "chezmoi edit --source=$HOME/dotfiles/chezmoi";
     cmu = "chezmoi update --source=$HOME/dotfiles/chezmoi";
   };
+
+  # Enable fontconfig to make fonts available to applications.
+  # On macOS, fonts are installed to ~/Library/Fonts/HomeManager and
+  # automatically registered with the system font database.
+  # See: https://nix-community.github.io/home-manager/options.xhtml#opt-fonts.fontconfig.enable
+  fonts.fontconfig.enable = true;
 }


### PR DESCRIPTION
## Summary

- Add declarative Nerd Font management using Home Manager's built-in [fontconfig support][hm-fontconfig]
- Install [JetBrains Mono Nerd Font][jb-nerd] to `~/Library/Fonts/HomeManager` on macOS
- Add `fonts` alias for quick access to the managed fonts directory

## How it works

Home Manager's [`fonts.fontconfig.enable`][hm-fontconfig] option handles font installation and registration:

1. Font packages added to `home.packages` are installed to the Nix store
2. Symlinks are created in `~/Library/Fonts/HomeManager/` (on macOS)
3. Fonts appear in Font Book and are available to all applications

This is the [recommended approach][nixos-asia-fonts] for declarative font management on macOS with Nix.

## Usage

After applying:

```bash
# Rebuild to install fonts
darwin-rebuild switch --flake ~/dotfiles/nix-darwin

# Verify installation
ls ~/Library/Fonts/HomeManager/
# Or use the new alias:
fonts
```

Configure applications to use the font:
- **Ghostty**: `font-family = JetBrainsMono Nerd Font`
- **VS Code**: `"editor.fontFamily": "JetBrainsMono Nerd Font"`

## Why Nerd Fonts?

[Nerd Fonts][nerd-fonts] patch developer fonts with additional glyphs (icons, powerline symbols). This enables richer terminal prompts (Starship) and editor experiences without emoji fallback issues.

## References

- [Home Manager fontconfig option][hm-fontconfig] - Official documentation
- [NixOS Wiki: Fonts][nixos-wiki-fonts] - Community guide on font management
- [Installing fonts using home-manager][nixos-asia-fonts] - Step-by-step tutorial
- [Nerd Fonts][nerd-fonts] - Project homepage

[hm-fontconfig]: https://nix-community.github.io/home-manager/options.xhtml#opt-fonts.fontconfig.enable
[nixos-wiki-fonts]: https://wiki.nixos.org/wiki/Fonts
[nixos-asia-fonts]: https://nixos.asia/en/howto/hm-fonts
[nerd-fonts]: https://www.nerdfonts.com/
[jb-nerd]: https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/JetBrainsMono

## Test plan

- [ ] Run `darwin-rebuild switch` successfully
- [ ] Verify fonts appear in `~/Library/Fonts/HomeManager/`
- [ ] Confirm font is visible in Font Book
- [ ] Test font rendering in a terminal (e.g., Ghostty)

🤖 Generated with [Claude Code](https://claude.ai/code)