### PR TITLE
feat(crush): disable Fireworks Response API data retention

### DIFF
--- a/chezmoi/dot_local/share/crush/crush.json
+++ b/chezmoi/dot_local/share/crush/crush.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://charm.land/crush.json",
   "providers": {
-    "openrouter": {
+    "openrouter-fireworks": {
       "type": "openai-compat",
       "base_url": "https://openrouter.ai/api/v1",
       "api_key": "$OPENROUTER_API_KEY",
@@ -20,15 +20,33 @@
           "default_max_tokens": 32768
         }
       ]
+    },
+    "openrouter": {
+      "type": "openai-compat",
+      "base_url": "https://openrouter.ai/api/v1",
+      "api_key": "$OPENROUTER_API_KEY",
+      "extra_body": {
+        "provider": {
+          "data_collection": "deny"
+        }
+      },
+      "models": [
+        {
+          "id": "google/gemini-2.5-flash-lite",
+          "name": "Gemini 2.5 Flash Lite (OpenRouter)",
+          "context_window": 1048576,
+          "default_max_tokens": 65536
+        }
+      ]
     }
   },
   "models": {
     "large": {
       "model": "moonshotai/kimi-k2.6",
-      "provider": "openrouter"
+      "provider": "openrouter-fireworks"
     },
     "small": {
-      "model": "moonshotai/kimi-k2.6",
+      "model": "google/gemini-2.5-flash-lite",
       "provider": "openrouter"
     }
   },

--- a/chezmoi/dot_local/share/crush/crush.json
+++ b/chezmoi/dot_local/share/crush/crush.json
@@ -9,12 +9,13 @@
         "provider": {
           "order": ["Fireworks"],
           "data_collection": "deny"
-        }
+        },
+        "store": false
       },
       "models": [
         {
-          "id": "moonshotai/kimi-k2.5",
-          "name": "Kimi K2.5 (OpenRouter/Fireworks)",
+          "id": "moonshotai/kimi-k2.6",
+          "name": "Kimi K2.6 (OpenRouter/Fireworks)",
           "context_window": 262144,
           "default_max_tokens": 32768
         }
@@ -23,11 +24,11 @@
   },
   "models": {
     "large": {
-      "model": "moonshotai/kimi-k2.5",
+      "model": "moonshotai/kimi-k2.6",
       "provider": "openrouter"
     },
     "small": {
-      "model": "moonshotai/kimi-k2.5",
+      "model": "moonshotai/kimi-k2.6",
       "provider": "openrouter"
     }
   },


### PR DESCRIPTION
## Summary

This PR makes two changes to the Crush config:

1. **Disable Fireworks Response API data retention** by setting `store: false` in the OpenRouter provider's `extra_body`. Fireworks retains conversation data for 30 days when `store=True` (the default) for the Response API specifically. Opting out keeps the zero-data-retention promise consistent with other Fireworks services.

2. **Split `large` and `small` models by capability and cost**. Previously both roles pointed to Kimi K2.5 — a large, expensive model — which is overkill for simple tasks. We now route `small` tasks to a purpose-built fast/cheap model while keeping `large` on Kimi K2.6 for complex reasoning and coding.

## Model Selection

We are not cost-sensitive to the point of using free-tier-only models, but we do want the right tool for the job. Below is the full set of small-model candidates we evaluated on OpenRouter.

### Candidates Considered

| Model | Provider | Input / 1M | Output / 1M | Context | Why we considered it | Why we passed |
|---|---|---|---|---|---|---|
| **openai/gpt-oss-20b** | Fireworks | **$0.03** | **$0.14** | 131K | Cheapest functional option; Fireworks explicitly recommends for low-latency tasks. | Quality ceiling is modest; we’re not optimizing for absolute minimum cost. |
| **meta-llama/llama-3.3-70b** | Various | **Free** / $0.10 | Free / $0.32 | 131K | Reliable workhorse; free tier available. | Free tier is rate-limited (20 req/min, 200/day); paid pricing is comparable to better options. |
| **mistralai/mistral-small-3.2-24b** | Mistral | $0.075 | $0.20 | 128K | Strong function calling; good instruction following. | Slightly more expensive than GPT-OSS-20B without the dramatic context-window or speed advantage of Gemini Flash Lite. |
| **qwen/qwen3-32b** | Alibaba | $0.08 | $0.24 | 131K | Dense 32B with thinking/non-thinking toggle; strong multilingual. | Not purpose-built for speed; Flash Lite beats it on latency and context. |
| **google/gemini-2.5-flash-lite** | Google | $0.10 | $0.40 | **1M** | **Purpose-built for speed and cost**; 1M context is unmatched at this price; ultra-low TTFT. | — |
| **anthropic/claude-haiku-4.5** | Anthropic | $1.00 | $5.00 | 200K | Near-frontier intelligence; best-in-class for accuracy-critical extraction. | **10× more expensive** than Gemini Flash Lite. The quality jump doesn’t justify the cost for "small" tasks. |

### Why Gemini 2.5 Flash Lite

- **Designed for exactly this role**: Google built Flash Lite as a fast, cost-efficient model for high-volume simple tasks (summarization, extraction, formatting, quick completions).
- **1M context window**: Orders of magnitude larger than other small-model options. Useful when `small` tasks still involve long documents.
- **Latency**: Ultra-low TTFT by design — faster than Kimi K2.6 for routine work.
- **Price**: At $0.10/$0.40 per 1M tokens, it’s only marginally more expensive than budget options (Mistral Small, Qwen3 32B) while being purpose-built for the use case.
- **Not Fireworks-bound**: We keep Fireworks for `large` because Kimi K2.6 is strongest there, but Flash Lite is a better fit for `small` and is hosted by Google via OpenRouter.

## Config Changes

| Role | Before | After |
|---|---|---|
| `large` | `moonshotai/kimi-k2.5` via `openrouter` | `moonshotai/kimi-k2.6` via **`openrouter-fireworks`** |
| `small` | `moonshotai/kimi-k2.5` via `openrouter` | `google/gemini-2.5-flash-lite` via **`openrouter`** |

- Renamed the Fireworks-specific provider to `openrouter-fireworks` so the `store: false` retention opt-out applies only to the large model.
- Added a generic `openrouter` provider for the small model with `data_collection: "deny"` (OpenRouter-level opt-out) but no Fireworks-specific `store: false`.

## Relevant docs

- [Fireworks — Data Handling & Zero Data Retention](https://docs.fireworks.ai/guides/security_compliance/data_handling)
- [OpenRouter — Provider Privacy & Logging](https://openrouter.ai/docs/guides/privacy/logging)
- [OpenRouter — Gemini 2.5 Flash Lite](https://openrouter.ai/google/gemini-2.5-flash-lite)

💘 Generated with Crush

Assisted-by: Kimi K2.6 (OpenRouter/Fireworks) via Crush <crush@charm.land>