### PR TITLE
feat(opencode): update Kimi model to K2.6

### DIFF
--- a/chezmoi/dot_config/opencode/opencode.json
+++ b/chezmoi/dot_config/opencode/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo",
+  "model": "fireworks-ai/accounts/fireworks/models/kimi-k2p6",
   "small_model": "opencode/mimo-v2-omni-free",
   "disabled_providers": [
     "gemini"
@@ -18,8 +18,8 @@
         "apiKey": "{env:OPENROUTER_API_KEY}"
       },
       "models": {
-        "moonshotai/kimi-k2.5": {
-          "name": "Kimi K2.5 (OpenRouter/Fireworks)",
+        "moonshotai/kimi-k2.6": {
+          "name": "Kimi K2.6 (OpenRouter/Fireworks)",
           "limit": {
             "context": 262144,
             "output": 32768


### PR DESCRIPTION
## Summary

This PR updates the OpenCode config to move our Kimi references from 2.5 to 2.6 while keeping the change scoped to `opencode.json` only.

1. **Switch the default Fireworks model** from the K2.5 turbo router to the direct K2.6 model ID we want to use in OpenCode.
2. **Update the OpenRouter Kimi entry** from `moonshotai/kimi-k2.5` to `moonshotai/kimi-k2.6` so the configured model key and display name stay aligned.

## Config Changes

| Setting | Before | After |
|---|---|---|
| `model` | `fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo` | `fireworks-ai/accounts/fireworks/models/kimi-k2p6` |
| `provider.openrouter.models` | `moonshotai/kimi-k2.5` / `Kimi K2.5 (OpenRouter/Fireworks)` | `moonshotai/kimi-k2.6` / `Kimi K2.6 (OpenRouter/Fireworks)` |

## Notes

- This branch intentionally changes only `chezmoi/dot_config/opencode/opencode.json`.
- I left the README and Crush config out of scope so this can merge independently of other local work.

## Relevant docs

- [Fireworks — Serverless Priority and Turbo](https://docs.fireworks.ai/guides/serverless-products)
- [OpenRouter — MoonshotAI: Kimi K2.6](https://openrouter.ai/moonshotai/kimi-k2.6)
- [OpenCode — Config](https://opencode.ai/docs/config/)
