### PR TITLE
docs(opencode): sync README with current Kimi config

### DIFF
--- a/chezmoi/dot_config/opencode/README.md
+++ b/chezmoi/dot_config/opencode/README.md
@@ -14,8 +14,8 @@ Configuration for [OpenCode][opencode], an AI-powered coding assistant.
 ### Configured Providers
 
 - **[OpenCode][opencode]** - `mimo-v2-pro-free`, `mimo-v2-omni-free`
-- **Fireworks AI** - `accounts/fireworks/routers/kimi-k2p5-turbo`
-- **[OpenRouter][openrouter]** - `moonshotai/kimi-k2.5`
+- **Fireworks AI** - `accounts/fireworks/models/kimi-k2p6`
+- **[OpenRouter][openrouter]** - `moonshotai/kimi-k2.6`
 - **[OpenAI][openai]** - GPT-5.x series (via OAuth/Codex)
 
 ### Authentication
@@ -32,7 +32,7 @@ disabled in config and no longer part of this setup. Fireworks AI uses
 
 ## Defaults
 
-- `model`: `fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo`
+- `model`: `fireworks-ai/accounts/fireworks/models/kimi-k2p6`
 - `small_model`: `opencode/mimo-v2-omni-free`
 
 ## Plugins


### PR DESCRIPTION
## Summary

This PR updates the OpenCode README so it matches the `opencode.json` that is already on `main`.

1. **Update the documented Fireworks default model** from the old K2.5 turbo router to the direct K2.6 model ID.
2. **Update the documented OpenRouter Kimi entry** from `moonshotai/kimi-k2.5` to `moonshotai/kimi-k2.6`.

## Why this is separate

- The runtime config change is already merged on `main` in #25.
- This branch is documentation-only and intentionally avoids the unrelated in-progress Executor refactor in my local worktree.

## Verification

- Compared the README entries against the checked-in `chezmoi/dot_config/opencode/opencode.json` on the branch.
- Confirmed the README now includes:
  - `fireworks-ai/accounts/fireworks/models/kimi-k2p6`
  - `moonshotai/kimi-k2.6`

## Relevant docs

- [OpenCode config docs](https://opencode.ai/docs/config/)
- [OpenRouter — MoonshotAI: Kimi K2.6](https://openrouter.ai/moonshotai/kimi-k2.6)
- [Fireworks — Serverless Priority and Turbo](https://docs.fireworks.ai/guides/serverless-products)
