### PR TITLE
feat: Ensure Fiberplane fp is on PATH when installed

### DIFF
--- a/chezmoi/dot_config/zsh/custom.zsh
+++ b/chezmoi/dot_config/zsh/custom.zsh
@@ -34,6 +34,7 @@ eval "$(mise activate zsh)"
 
 # Only append to PATH if these directories aren't already there
 [[ ":$PATH:" != *":$HOME/.opencode/bin:"* ]] && export PATH="$PATH:$HOME/.opencode/bin"
+[[ -x "$HOME/.fiberplane/bin/fp" ]] && [[ ":$PATH:" != *":$HOME/.fiberplane/bin:"* ]] && export PATH="$PATH:$HOME/.fiberplane/bin"
 [[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && export PATH="$PATH:$HOME/.local/bin"
 [[ ":$PATH:" != *":$HOME/.cargo/bin:"* ]] && export PATH="$PATH:$HOME/.cargo/bin"
 [[ ":$PATH:" != *":$HOME/go/bin:"* ]] && export PATH="$PATH:$HOME/go/bin"


### PR DESCRIPTION
## Summary
- add a guarded PATH append in the managed zsh config for ~/.fiberplane/bin
- only add that directory when ~/.fiberplane/bin/fp exists
- keep the change entirely under chezmoi-managed shell config

## Validation
- zsh -n chezmoi/dot_config/zsh/custom.zsh