### PR TITLE
chore: update executor to 1.4.9

### DIFF
--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -23,7 +23,7 @@ bun = "latest"
 "npm:@google/gemini-cli" = "0.34.0"
 "npm:@openai/codex" = "0.116.0"
 "npm:markit-ai" = "0.5.0"       # exception: first npm release was 2026-03-25, so no 7-day-old version exists yet
-"npm:executor" = "1.4.8"        # pin for local-first control-plane OpenAPI support
+"npm:executor" = "1.4.9"        # pin for scoped OpenAPI credential upgrade fixes
 "npm:agent-browser" = "0.22.0"
 
 # ============================================================================

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -17,7 +17,7 @@ registers MCP and OpenAPI sources.
 | `scripts/executor/sync.sh` | Reconciles the desired source inventory into Executor |
 | `scripts/executor/launchd-sync.sh` | Rebuilds shell env for launchd-driven runs |
 | `scripts/executor/restart.sh` | Stops the runtime and re-runs sync |
-| `scripts/executor/status.sh` | Prints runtime + source inventory |
+| `scripts/executor/status.sh` | Prints runtime + source inventory via Executor CLI, with a direct API fallback |
 | LaunchAgent | Starts sync on login and every 15 minutes |
 
 ## Source Types
@@ -75,11 +75,8 @@ See
    `executor daemon run --port 8788 --hostname 127.0.0.1 --scope ~/.executor`
    via a detached tmux launch wrapper and waits for `/api/docs`.
 6. For each desired source, `sync.sh` compares with `GET /api/scopes/:id/{mcp,openapi}/sources/:ns` and PATCHes, POSTs, or DELETE+POSTs as needed. On add/patch it triggers a tool refresh.
-7. If `~/.executor/executor.jsonc` is still in the legacy object-shaped format,
-   `sync.sh` backs it up and replaces it with a modern empty `sources` array
-   before reconciliation.
-8. Secret-backed sources are written as secret references, not literal tokens.
-9. Executor persists sources in SQLite, so subsequent runs are cheap — unchanged sources return a "already up to date" line without touching the server.
+7. Secret-backed sources are written as secret references, not literal tokens.
+8. Executor persists sources in SQLite, so subsequent runs are cheap — unchanged sources return a "already up to date" line without touching the server.
 
 ## Manual Operations
 
@@ -92,6 +89,9 @@ See
 
 # Show runtime + source inventory.
 ./scripts/executor/status.sh
+
+# Ask Executor directly for source metadata and tool counts.
+executor tools sources --base-url http://127.0.0.1:8788 --scope ~/.executor
 
 # Inspect the live control-plane OpenAPI spec.
 curl -s http://127.0.0.1:8788/api/docs \
@@ -107,12 +107,9 @@ tail -f ~/Library/Logs/com.kchen.executor-sync.log
 
 - `status.sh` is the first stop. It fails fast if the runtime is unreachable.
 - Runtime wedged? `restart.sh`. Source state is preserved in SQLite; only the process is replaced.
-- If source adds fail right after a version upgrade, inspect `~/.executor` for a
-  `executor.jsonc.legacy-*.bak` backup. `sync.sh` rewrites the old object-shaped
-  file because Executor `1.4.8` expects `sources` to be an array.
-- `executor.jsonc` may stay sparse right after a legacy migration because the
-  authoritative catalog already lives in SQLite. A fresh scope or empty catalog
-  is rebuilt fully by `sync.sh`.
+- `executor.jsonc` may stay sparse after an Executor data upgrade because the
+  authoritative catalog lives in SQLite. A fresh scope or empty catalog is
+  rebuilt fully by `sync.sh`.
 - Source marked "auth required" or failing to refresh? Check that the
   corresponding env var is actually in the environment (launchd has a minimal
   env — credentials must be in `~/.config/shell/*.sh`).

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -176,7 +176,7 @@ Executor automation is co-located under `scripts/executor/`:
 - `sync.sh`: desired source inventory plus idempotent reconciliation
 - `launchd-sync.sh`: launchd-friendly PATH/env bootstrap that delegates to `sync.sh`
 - `restart.sh`: stop the runtime and re-run `sync.sh`
-- `status.sh`: print runtime + source inventory
+- `status.sh`: print runtime + source inventory through Executor's CLI, with a direct API fallback
 
 Every managed source is a hosted remote HTTP endpoint (MCP or OpenAPI) — no
 stdio bridges, no supergateway. Auth is usually header-based and env-driven,
@@ -189,9 +189,8 @@ The `sync.sh` script:
 2. Reconciles each desired source against `GET /api/scopes/:id/{mcp,openapi}/sources/:namespace` — PATCHes a drift, POSTs a new source, or DELETE+POSTs when an immutable field changed.
 3. Stores auth material in Executor's own secret store and references secrets from source configs instead of writing raw tokens into `executor.jsonc`.
 4. Triggers a tool refresh on each MCP source after add/update.
-5. Migrates a legacy object-shaped `executor.jsonc` to the modern array-based format before any add path runs.
-6. Reloads the credential fragments in `~/.config/shell/*.sh` so manual runs do not reuse stale secret exports.
-7. Skips sources whose credentials are not in the environment, except for
+5. Reloads the credential fragments in `~/.config/shell/*.sh` so manual runs do not reuse stale secret exports.
+6. Skips sources whose credentials are not in the environment, except for
    sources that can run from a stored Executor OAuth connection (currently
    Atlassian via `atlassian_oauth`).
 

--- a/scripts/executor/status.sh
+++ b/scripts/executor/status.sh
@@ -8,9 +8,33 @@ SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 BASE_URL="$EXECUTOR_BASE_URL"
+EXECUTOR_BIN="$(prefer_fallback_bin executor "$EXECUTOR_MISE_SHIM")"
 JQ_BIN="$(require_bin jq)"
 CURL_BIN="$(require_bin curl)"
 LSOF_BIN="$(resolve_bin lsof || true)"
+
+daemon_status_file="$(mktemp "${TMPDIR:-/tmp}/executor-daemon-status.XXXXXX")"
+sources_file="$(mktemp "${TMPDIR:-/tmp}/executor-tools-sources.XXXXXX")"
+trap 'rm -f "$daemon_status_file" "$sources_file"' EXIT
+
+if "$EXECUTOR_BIN" daemon status --base-url "$BASE_URL" >"$daemon_status_file" 2>/dev/null; then
+  cat "$daemon_status_file"
+  echo
+
+  if "$EXECUTOR_BIN" tools sources \
+    --base-url "$BASE_URL" \
+    --scope "$EXECUTOR_SCOPE_DIR" >"$sources_file" 2>/dev/null; then
+    printf '%-18s %-10s %-28s %s\n' "ID" "KIND" "NAME" "TOOLS"
+    printf '%-18s %-10s %-28s %s\n' "--" "----" "----" "-----"
+    "$JQ_BIN" -r '.[] | [.id, .kind, .name, .toolCount] | @tsv' "$sources_file" |
+      while IFS=$'\t' read -r source_id kind name tool_count; do
+        printf '%-18s %-10s %-28s %s\n' "$source_id" "$kind" "$name" "$tool_count"
+      done
+    exit 0
+  fi
+
+  warn "executor tools sources failed; falling back to direct control-plane API"
+fi
 
 if ! scope_json="$("$CURL_BIN" -fsS "${BASE_URL%/}/api/scope" 2>/dev/null)"; then
   error "Executor runtime is not reachable at ${BASE_URL%/}"

--- a/scripts/executor/sync.sh
+++ b/scripts/executor/sync.sh
@@ -32,34 +32,6 @@ HTTP_BODY=""
 FAILURES=()
 SKIPPED=()
 
-migrate_legacy_scope_config() {
-  local config_file="$EXECUTOR_SCOPE_DIR/executor.jsonc"
-  local sources_type backup_file
-
-  [[ -f "$config_file" ]] || return 0
-
-  sources_type="$("$JQ_BIN" -r '
-    if type == "object" and has("sources") then
-      (.sources | type)
-    else
-      ""
-    end
-  ' "$config_file" 2>/dev/null || true)"
-
-  [[ "$sources_type" == "object" ]] || return 0
-
-  backup_file="${config_file}.legacy-$(date +%Y%m%d%H%M%S).bak"
-  cp "$config_file" "$backup_file"
-  cat >"$config_file" <<'EOF'
-{
-  "sources": []
-}
-EOF
-
-  warn "Backed up legacy Executor config to $backup_file"
-  warn "Reset object-shaped executor.jsonc to a modern empty source array"
-}
-
 api() {
   local method="$1" path="$2" payload="${3:-}"
   local body_file; body_file="$(mktemp "${TMPDIR:-/tmp}/executor-api.XXXXXX")"
@@ -115,7 +87,6 @@ start_runtime() {
 
 ensure_runtime() {
   mkdir -p "$EXECUTOR_SCOPE_DIR"
-  migrate_legacy_scope_config
 
   if api GET /scope; then
     local dir; dir="$(printf '%s' "$HTTP_BODY" | "$JQ_BIN" -r '.dir // empty' 2>/dev/null || true)"


### PR DESCRIPTION
## Summary
- bump Mise-managed Executor from 1.4.8 to 1.4.9
- use Executor's daemon/status and tools sources CLI in status.sh, with the existing direct API path as fallback
- remove the local legacy executor.jsonc rewrite workaround and update docs to rely on Executor's data upgrades

## Verification
- bash -n scripts/executor/sync.sh scripts/executor/status.sh scripts/executor/restart.sh scripts/executor/common.sh scripts/executor/launchd-sync.sh
- ./scripts/executor/status.sh
- git diff --check