### PR TITLE
feat(ghostty): enable transparent glass window

### DIFF
--- a/chezmoi/dot_config/ghostty/config
+++ b/chezmoi/dot_config/ghostty/config
@@ -3,3 +3,6 @@ theme = light:Rose Pine Dawn,dark:Rose Pine
 window-padding-x = 7,12
 window-padding-y = 7,12
 selection-invert-fg-bg = true
+background-opacity = 0.0
+background-blur = macos-glass-clear
+macos-titlebar-style = transparent


### PR DESCRIPTION
## Summary
- enable fully transparent Ghostty background
- use macOS glass blur
- make the Ghostty titlebar transparent

## Testing
- Not run; config-only change.