### PR TITLE
chore(mise): update go and golangci-lint

### DIFF
--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -9,7 +9,7 @@
 # ============================================================================
 node = "24"
 python = "latest"
-go = "latest"
+go = "1.26.3"
 rust = "latest"
 
 # ============================================================================
@@ -48,7 +48,6 @@ bun = "latest"
 "github:charmbracelet/glow" = "latest"  # markdown renderer (Go)
 "github:charmbracelet/gum" = "latest"   # shell prompt tool (Go)
 "go:golang.org/x/vuln/cmd/govulncheck" = "latest"  # Go vulnerability scanner
-"go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "latest"  # Go linter aggregator
 
 # ============================================================================
 # Tools from GitHub Releases (Go & other binaries)
@@ -65,6 +64,7 @@ bun = "latest"
 "aqua:mikefarah/yq" = "latest"  # YAML processor
 "aqua:terrastruct/d2" = "latest"  # Diagram language
 "aqua:typst/typst" = "latest"   # Typesetting system
+"aqua:golangci/golangci-lint" = "2.12.2"  # Go linter aggregator
 "github:astral-sh/uv" = "latest"  # Python package manager
 "aqua:planetscale/cli" = "latest"  # PlanetScale database CLI (pscale)
 "aqua:aws/aws-cli" = "latest"          # AWS CLI


### PR DESCRIPTION
## Summary
- pin Go to 1.26.3 in the Chezmoi-managed Mise config
- switch golangci-lint from `go install` to Mise's aqua-backed binary source and pin it to 2.12.2

## Verification
- `mise install --yes go@1.26.3 aqua:golangci/golangci-lint@2.12.2`
- `mise exec go@1.26.3 -- go version`
- `mise exec aqua:golangci/golangci-lint@2.12.2 -- golangci-lint version`
- `git diff --check`

## Notes
- `chezmoi apply --source="$PWD/chezmoi"` was attempted but local 1Password CLI authentication is unavailable in this workspace, so template rendering stopped on `op://Software/Cerebras/CEREBRAS_API_KEY` before the Mise config could be applied through Chezmoi.
