### PR TITLE
feat(mise): add Hunk diff viewer

### DIFF
--- a/chezmoi/dot_config/hunk/config.toml
+++ b/chezmoi/dot_config/hunk/config.toml
@@ -1,0 +1,1 @@
+theme = "auto"

--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -25,6 +25,7 @@ bun = "latest"
 "npm:markit-ai" = "0.5.0"       # exception: first npm release was 2026-03-25, so no 7-day-old version exists yet
 "npm:executor" = "1.4.15"       # pin to first complete post-1.4.8 packaging + policy release
 "npm:agent-browser" = "0.22.0"
+"npm:hunkdiff" = "0.12.0"       # review-first terminal diff viewer
 
 # ============================================================================
 # Development Tools from Cargo (Rust tools)


### PR DESCRIPTION
## Summary
- add Hunk (`hunkdiff`) to the Chezmoi-managed Mise tool list
- configure Hunk to use automatic light/dark theming
- keep the existing Git delta pager unchanged

## Verification
- `python3 -c 'import tomllib; tomllib.load(open("chezmoi/dot_config/mise/config.toml", "rb")); tomllib.load(open("chezmoi/dot_config/hunk/config.toml", "rb")); print("toml ok")'`
- `MISE_CONFIG_FILE=$PWD/chezmoi/dot_config/mise/config.toml mise install npm:hunkdiff@0.12.0`
- `MISE_CONFIG_FILE=$PWD/chezmoi/dot_config/mise/config.toml mise exec npm:hunkdiff@0.12.0 -- hunk --version`
