### PR TITLE
Fix Executor daemon MCP wiring and secret guidance

### DIFF
--- a/chezmoi/dot_codex/modify_private_config.toml.tmpl
+++ b/chezmoi/dot_codex/modify_private_config.toml.tmpl
@@ -17,8 +17,7 @@ path = Path(sys.argv[1])
 text = path.read_text()
 
 block = '''[mcp_servers.executor]
-command = "{{ .chezmoi.homeDir }}/.local/share/mise/shims/executor"
-args = ["mcp", "--scope", "{{ .chezmoi.homeDir }}/.executor"]
+url = "http://127.0.0.1:8788/mcp"
 
 '''
 

--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -23,7 +23,7 @@ bun = "latest"
 "npm:@google/gemini-cli" = "0.34.0"
 "npm:@openai/codex" = "0.116.0"
 "npm:markit-ai" = "0.5.0"       # exception: first npm release was 2026-03-25, so no 7-day-old version exists yet
-"npm:executor" = "1.4.15"       # pin to first complete post-1.4.8 packaging + policy release
+"npm:executor" = "1.4.28"       # desktop release + DB-owned source state; keep pinned across schema migrations
 "npm:agent-browser" = "0.22.0"
 "npm:hunkdiff" = "0.12.0"       # review-first terminal diff viewer
 

--- a/chezmoi/modify_dot_claude.json.tmpl
+++ b/chezmoi/modify_dot_claude.json.tmpl
@@ -5,14 +5,13 @@
 set -euo pipefail
 
 # Define the MCP servers configuration.
-# Use command-backed MCP so Claude can start Executor against the shared user scope
-# from any project directory.
+# Use the shared HTTP daemon so Claude does not spawn a separate Executor
+# runtime for every project/session.
 MCP_CONFIG='{
   "mcpServers": {
     "executor": {
-      "type": "stdio",
-      "command": "{{ .chezmoi.homeDir }}/.local/share/mise/shims/executor",
-      "args": ["mcp", "--scope", "{{ .chezmoi.homeDir }}/.executor"]
+      "type": "http",
+      "url": "http://127.0.0.1:8788/mcp"
     }
   }
 }'

--- a/chezmoi/run_after_04_load-executor-daemon-launch-agent.sh
+++ b/chezmoi/run_after_04_load-executor-daemon-launch-agent.sh
@@ -38,6 +38,11 @@ if [[ ! -x "$ENTRYPOINT" ]]; then
 fi
 
 if launchctl print "${DOMAIN}/${LABEL}" >/dev/null 2>&1; then
+  if [[ "${EXECUTOR_FORCE_LAUNCHD_RELOAD:-0}" != "1" ]]; then
+    echo "LaunchAgent ${LABEL} already loaded; leaving the Executor daemon running"
+    echo "Set EXECUTOR_FORCE_LAUNCHD_RELOAD=1 or run scripts/executor/restart.sh to restart it"
+    exit 0
+  fi
   launchctl bootout "${DOMAIN}/${LABEL}" >/dev/null 2>&1 || true
 fi
 

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -8,18 +8,20 @@ The default shared scope is:
 
 - `~/.executor`
 
+This repo pins Executor to `1.4.28`, the first local release where source state
+is clearly database-owned again. `executor.jsonc` is an optional plugin manifest,
+not the source catalog.
+
 ## Client Wiring
 
-Codex and Claude use command-backed MCP through the Mise shim:
-
-```bash
-~/.local/share/mise/shims/executor mcp --scope ~/.executor
-```
-
-OpenCode and Crush are still URL-backed clients, so launchd keeps the local
-daemon endpoint available:
+Codex, Claude, OpenCode, and Crush all use the shared HTTP MCP daemon:
 
 - `http://127.0.0.1:8788/mcp`
+
+Do not wire normal agent clients to `executor mcp --scope ~/.executor` unless a
+client cannot speak streamable HTTP MCP. Command-backed MCP spawns an Executor
+runtime per client session, which can duplicate source state work and repeat
+macOS Keychain probes.
 
 ## Ownership
 
@@ -42,6 +44,10 @@ Executor owns:
 Do not periodically rewrite Executor sources from dotfiles. That turns bash into
 a second control plane and fights Executor's own runtime model.
 
+Since Executor `1.4.28`, source configuration is no longer replayed from or
+written back to `executor.jsonc`. Live source definitions, source credentials,
+and source auth bindings are SQLite-backed runtime state.
+
 ## Scripts
 
 | Script | Purpose |
@@ -49,6 +55,7 @@ a second control plane and fights Executor's own runtime model.
 | `scripts/executor/launchd-daemon.sh` | launchd entrypoint; runs the shared Executor daemon in foreground |
 | `scripts/executor/restart.sh` | stops the daemon and restarts it through launchd |
 | `scripts/executor/status.sh` | prints daemon reachability, version, scope, source inventory, and policy count |
+| `scripts/executor/doctor.sh` | prints safe diagnostics for daemon, launchd, process, config, and keychain-prompt triage |
 | `scripts/executor/ensure-readonly-search-policies.sh` | idempotently approves exact read-only Perplexity and Parallel search tools |
 | `scripts/executor/common.sh` | shared constants and helper functions |
 
@@ -60,27 +67,21 @@ nested scopes remain authoritative inside Executor.
 
 Chezmoi should manage the pieces that are stable text config:
 
-- agent client wiring that points at `executor mcp --scope ~/.executor`
+- agent client wiring that points at `http://127.0.0.1:8788/mcp`
 - the launchd plist and foreground daemon entrypoint
 - helper scripts and operator docs
 - machine-wide policy bootstrap for exact low-risk tools
 
-Chezmoi should not own `~/.executor/executor.jsonc` wholesale. That file can
-contain source definitions, generated OpenAPI specs, secret references, and
-remote MCP connection details that drift as Executor evolves. Treating it as a
-rendered dotfile makes Chezmoi a second source catalog and can overwrite live
-OAuth-backed sources.
+Chezmoi should not own `~/.executor/executor.jsonc` wholesale. On Executor
+`1.4.28+`, that file should only be treated as an optional plugin manifest.
+Sources, generated OpenAPI specs, secret references, and remote MCP auth
+bindings belong in Executor's runtime database and should be edited through the
+control plane.
 
-If a stale source in `executor.jsonc` clobbers live Executor state, remove only
-that entry and repair the live source through the control plane. For Atlassian,
-the expected live source auth is:
-
-```json
-{
-  "kind": "oauth2",
-  "connectionId": "atlassian_oauth"
-}
-```
+If `doctor.sh` reports a lingering `sources` key in `executor.jsonc`, treat it
+as legacy state. Do not port it into dotfiles; verify the live source in
+Executor's UI/CLI and remove the stale config entry only after the database copy
+is healthy.
 
 ## LaunchAgent
 
@@ -102,6 +103,41 @@ executor daemon run --foreground \
 ```
 
 launchd supervises the foreground process with `KeepAlive`.
+
+The Chezmoi LaunchAgent hook is intentionally idempotent. If the LaunchAgent is
+already loaded, `chezmoi apply` leaves the daemon running instead of booting it
+out and starting a fresh process. This avoids unnecessary keychain probes and
+keeps source/OAuth state warm. Use `scripts/executor/restart.sh` or set
+`EXECUTOR_FORCE_LAUNCHD_RELOAD=1` for an intentional launchd reload.
+
+## Secrets
+
+Executor source credentials should use Executor secret providers, not committed
+env blocks or checked-in source definitions.
+
+| Backend | Use When | Notes |
+| --- | --- | --- |
+| 1Password | API tokens already live in 1Password | Preferred for Exa, Perplexity, Parallel, Firecrawl, and similar source credentials |
+| macOS Keychain | You specifically want OS-keychain storage | Encrypted at rest, but macOS can prompt when Executor probes or reads entries |
+| file-secrets | Local throwaway development only | Plain JSON on disk; do not use for durable personal API tokens |
+
+For Exa, keep the global `exa` source in `~/.executor`, keep the API key in
+1Password, and bind the source credential to the 1Password-backed Executor
+secret. The shell `EXA_API_KEY` template can remain for non-Executor CLIs, but
+Executor sources should not rely on committed env wiring.
+
+If macOS repeatedly asks for a Keychain password:
+
+- Run `./scripts/executor/doctor.sh` and check whether multiple Executor
+  processes are running.
+- Avoid restarting launchd unless needed; `chezmoi apply` no longer restarts an
+  already loaded Executor daemon by default.
+- Keep Codex and Claude on the HTTP MCP URL so they do not spawn extra
+  command-backed Executor runtimes.
+- Prefer migrating source credentials to the 1Password provider so Executor does
+  not need to store new source secrets in Keychain.
+- Expect one-time prompts after an Executor binary upgrade if existing secrets
+  still live in Keychain.
 
 ## Project Scopes
 
@@ -166,6 +202,9 @@ being approved.
 # Show daemon + source inventory.
 ./scripts/executor/status.sh
 
+# Show safe daemon/process/keychain diagnostics.
+./scripts/executor/doctor.sh
+
 # Restart the daemon through launchd.
 ./scripts/executor/restart.sh
 
@@ -189,11 +228,8 @@ tail -f ~/.local/state/executor/logs/runtime.log
 - Runtime wedged? Run `restart.sh`.
 - If `restart.sh` says the LaunchAgent is not loaded, run `chezmoi apply` from
   the real `~/dotfiles` checkout so launchd points at an existing script.
-- Atlassian source present but zero tools? Check whether `executor.jsonc`
-  contains an `atlassian` source entry. A stale entry can sync without OAuth and
-  replace the live source with `auth: none`. Remove that stale config-file entry,
-  bind the live source to the `atlassian_oauth` connection, and run the
-  MCP-specific source refresh.
+- Repeated Keychain prompts? Run `doctor.sh`; if there are multiple Executor
+  processes, stop the extras and keep the launchd daemon as the shared runtime.
 - Source auth broken? Fix it in Executor's UI/CLI, not in dotfiles.
 - Project-only MCPs should move to project scopes when Executor's nested-scope
   flow is ready.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -11,6 +11,7 @@ configurations. Scripts are **idempotent** and **non-destructive**.
 | -------------- | ------------------------------------- |
 | `bootstrap.sh` | First-time setup for new machines     |
 | `executor/common.sh` | Shared constants and helpers for executor automation |
+| `executor/doctor.sh` | Safe Executor daemon/process/keychain diagnostics |
 | `executor/launchd-daemon.sh` | Run the shared Executor daemon under launchd |
 | `executor/restart.sh` | Stop and restart the Executor daemon |
 | `executor/status.sh` | Print executor runtime + source inventory |
@@ -174,6 +175,7 @@ Executor automation is co-located under `scripts/executor/`:
 - `common.sh`: shared paths, constants, and helper functions
 - `launchd-daemon.sh`: launchd-friendly PATH/bootstrap that execs the Executor daemon in foreground
 - `ensure-readonly-search-policies.sh`: exact machine-wide approvals for read-only Perplexity and Parallel search
+- `doctor.sh`: safe diagnostics for daemon, launchd, processes, legacy config, and keychain-prompt triage
 - `restart.sh`: stop and restart the daemon
 - `status.sh`: print runtime + source inventory
 
@@ -182,6 +184,15 @@ future workspace/nested-scope data. Do not add a steady-state source reconciler
 back into dotfiles; manage sources through Executor UI/CLI. Machine-wide policy
 seeding should stay exact and limited to tools that are truly read-only across
 projects.
+
+On Executor 1.4.28+, `~/.executor/executor.jsonc` is only an optional plugin
+manifest. Do not use it as a source catalog, and do not add source replay from
+that file back into the launchd entrypoint.
+
+Codex, Claude, OpenCode, and Crush should use the shared HTTP endpoint at
+`http://127.0.0.1:8788/mcp`. Avoid command-backed `executor mcp --scope
+~/.executor` wiring unless a client has no HTTP MCP support; each command-backed
+session can spawn its own Executor runtime and repeat macOS Keychain probes.
 
 Canonical architecture and runtime notes live in [docs/executor.md](../docs/executor.md).
 
@@ -208,6 +219,11 @@ The `executor/launchd-daemon.sh` script:
 
 It is the entrypoint used by the macOS LaunchAgent that keeps Executor available
 after login.
+
+The Chezmoi LaunchAgent hook leaves an already loaded daemon running by default.
+This avoids unnecessary Executor restarts and repeated macOS Keychain probes.
+Use `scripts/executor/restart.sh` or `EXECUTOR_FORCE_LAUNCHD_RELOAD=1 chezmoi
+apply` when an intentional launchd reload is needed.
 
 ## CLEANUP SCRIPT
 

--- a/scripts/executor/doctor.sh
+++ b/scripts/executor/doctor.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Print safe Executor diagnostics without reading secret values.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/executor/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+EXECUTOR_BIN="$(prefer_fallback_bin executor "$EXECUTOR_MISE_SHIM")"
+CURL_BIN="$(require_bin curl)"
+JQ_BIN="$(require_bin jq)"
+
+printf 'Executor CLI: %s\n' "$(executor_version "$EXECUTOR_BIN")"
+printf 'Expected scope: %s\n' "$EXECUTOR_SCOPE_DIR"
+printf 'Daemon URL: %s\n' "${EXECUTOR_BASE_URL%/}"
+
+if scope_json="$("$CURL_BIN" -fsS "${EXECUTOR_BASE_URL%/}/api/scope" 2>/dev/null)"; then
+  printf 'Daemon: reachable\n'
+  printf 'Active scope: %s\n' "$(printf '%s' "$scope_json" | "$JQ_BIN" -r '.dir // .id // empty')"
+else
+  printf 'Daemon: not reachable\n'
+fi
+
+if [[ "${OSTYPE:-}" == darwin* ]] && command -v launchctl >/dev/null 2>&1; then
+  label="com.kchen.executor-daemon"
+  domain="gui/$(id -u)"
+  if launchctl print "${domain}/${label}" >/dev/null 2>&1; then
+    printf 'LaunchAgent: loaded (%s/%s)\n' "$domain" "$label"
+  else
+    printf 'LaunchAgent: not loaded (%s/%s)\n' "$domain" "$label"
+  fi
+fi
+
+if command -v pgrep >/dev/null 2>&1; then
+  printf '\nExecutor processes:\n'
+  process_list="$(pgrep -fl 'executor( |$|-)' || true)"
+  if [[ -z "$process_list" ]]; then
+    printf '  none found\n'
+  else
+    printf '%s\n' "$process_list"
+    process_count="$(printf '%s\n' "$process_list" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')"
+    if [[ "$process_count" -gt 2 ]]; then
+      printf '  warning: multiple Executor processes can repeat startup probes; prefer the shared HTTP daemon\n'
+    fi
+  fi
+fi
+
+config_file="${EXECUTOR_SCOPE_DIR%/}/executor.jsonc"
+if [[ -f "$config_file" ]]; then
+  printf '\nConfig file: %s\n' "$config_file"
+  if grep -Eq '"sources"[[:space:]]*:' "$config_file"; then
+    printf '  contains a sources key; Executor 1.4.28+ keeps live sources in SQLite, not this file\n'
+  fi
+  if grep -Eq '"plugins"[[:space:]]*:' "$config_file"; then
+    printf '  contains plugin entries\n'
+  fi
+fi
+
+cat <<'EOF'
+
+Keychain prompt notes:
+  macOS prompts can happen when Executor's built-in keychain provider probes or
+  reads OS Keychain entries. Repeated Executor process restarts can repeat that
+  probe. This dotfiles repo keeps launchd idempotent by default; use
+  scripts/executor/restart.sh only when you intentionally want a restart.
+
+  Codex, Claude, OpenCode, and Crush should point at the shared HTTP MCP daemon
+  instead of spawning command-backed `executor mcp` processes.
+
+  Prefer Executor's 1Password provider for API tokens you already keep in
+  1Password. Avoid storing new Executor source credentials in the macOS
+  Keychain unless you specifically want that backend.
+EOF

--- a/scripts/executor/restart.sh
+++ b/scripts/executor/restart.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Stop the Executor runtime and re-run sync. Source state lives in SQLite, so
-# this is only needed when the runtime process itself is wedged.
+# Stop and restart the Executor runtime. Source state lives in SQLite, so this
+# is only needed when the runtime process itself is wedged or launchd settings
+# changed.
 
 set -euo pipefail
 

--- a/scripts/executor/status.sh
+++ b/scripts/executor/status.sh
@@ -45,42 +45,15 @@ tool_count_for_source() {
   "$CURL_BIN" -fsS "${BASE_URL%/}/api/scopes/$SCOPE_ID/sources/$source_id/tools" | "$JQ_BIN" 'length'
 }
 
-show_mcp_source() {
-  local namespace="$1" source_json name tool_count
-  source_json="$("$CURL_BIN" -fsS "${BASE_URL%/}/api/scopes/$SCOPE_ID/mcp/sources/$namespace" 2>/dev/null || true)"
-  [[ -n "$source_json" && "$source_json" != "null" ]] || return 0
-  name="$(printf '%s' "$source_json" | "$JQ_BIN" -r '.name // .namespace')"
-  tool_count="$(tool_count_for_source "$namespace")"
-  print_row "$namespace" "mcp" "$name" "$tool_count"
-}
-
-show_openapi_source() {
-  local namespace="$1" source_json name tool_count
-  source_json="$("$CURL_BIN" -fsS "${BASE_URL%/}/api/scopes/$SCOPE_ID/openapi/sources/$namespace" 2>/dev/null || true)"
-  [[ -n "$source_json" && "$source_json" != "null" ]] || return 0
-  name="$(printf '%s' "$source_json" | "$JQ_BIN" -r '.name // .namespace')"
-  tool_count="$(tool_count_for_source "$namespace")"
-  print_row "$namespace" "openapi" "$name" "$tool_count"
-}
-
-show_control_source() {
-  local source_id="$1" name="$2" tool_count
-  tool_count="$(tool_count_for_source "$source_id" 2>/dev/null || true)"
-  [[ -n "$tool_count" ]] || return 0
-  print_row "$source_id" "control" "$name" "$tool_count"
-}
-
-show_mcp_source "deepwiki"
-show_mcp_source "grep"
-show_mcp_source "exa"
-show_mcp_source "github"
-show_mcp_source "firecrawl"
-show_mcp_source "atlassian"
-show_control_source "graphql" "GraphQL"
-show_openapi_source "executor_control"
-show_control_source "openapi" "OpenAPI"
-show_openapi_source "parallel_search"
-show_openapi_source "perplexity_search"
+sources_json="$("$CURL_BIN" -fsS "${BASE_URL%/}/api/scopes/$SCOPE_ID/sources" 2>/dev/null || true)"
+if [[ -n "$sources_json" && "$sources_json" != "null" ]]; then
+  printf '%s' "$sources_json" \
+    | "$JQ_BIN" -r '.[] | [.id, .kind, (.name // .id)] | @tsv' \
+    | while IFS=$'\t' read -r source_id kind name; do
+      tool_count="$(tool_count_for_source "$source_id" 2>/dev/null || printf '?')"
+      print_row "$source_id" "$kind" "$name" "$tool_count"
+    done
+fi
 
 policies_json="$("$CURL_BIN" -fsS "${BASE_URL%/}/api/scopes/$SCOPE_ID/policies" 2>/dev/null || true)"
 if [[ -n "$policies_json" && "$policies_json" != "null" ]]; then


### PR DESCRIPTION
## Summary

- upgrade Mise-managed Executor from 1.4.15 to 1.4.28
- switch Codex and Claude Executor MCP config from command-backed stdio to the shared HTTP daemon
- make the Executor LaunchAgent hook idempotent by default to avoid unnecessary daemon restarts
- add `scripts/executor/doctor.sh` for safe daemon/process/keychain diagnostics
- update Executor docs for 1.4.28 source-state ownership, global sources, 1Password-first secrets, and keychain prompt triage
- make `status.sh` list sources through Executor's generic source inventory endpoint

## Verification

- `bash -n scripts/executor/*.sh chezmoi/run_after_04_load-executor-daemon-launch-agent.sh chezmoi/run_after_05_configure-executor-readonly-policies.sh chezmoi/dot_codex/modify_private_config.toml.tmpl chezmoi/modify_dot_claude.json.tmpl`
- `printf '' | bash chezmoi/dot_codex/modify_private_config.toml.tmpl`
- `printf '{"other": true}' | bash chezmoi/modify_dot_claude.json.tmpl | jq .`
- `git diff --check`
- `mise install npm:executor@1.4.28`
- `~/.local/share/mise/installs/npm-executor/1.4.28/bin/executor --version`
- `chezmoi apply --verbose` from the real `~/dotfiles` checkout after rebasing on latest `origin/main`
- `./scripts/executor/status.sh` against the live daemon: Executor CLI 1.4.28, 11 sources, 2 policy rules
- HTTP MCP `initialize` against `http://127.0.0.1:8788/mcp`
- Codex `mcp get executor`: `transport: streamable_http`
- Claude `~/.claude.json`: `{ "type": "http", "url": "http://127.0.0.1:8788/mcp" }`
- Live read-only smoke calls through Executor MCP:
  - `exa.web_search_exa`
  - `parallel_search.search.webSearchV1betaSearchPost`
  - `perplexity_search.search.searchSearchPost`

## Notes

Live rollout was completed from `~/dotfiles` after preserving the pre-existing dirty checkout as `stash@{0}: before-executor-pr38-live-apply`. The stale Bun-global `executor@1.4.8` was removed, stale `executor mcp` processes from 1.4.15 were killed, and launchd is now running the 1.4.28 daemon on `127.0.0.1:8788`.

`mise prune` printed warnings about unrelated untrusted/unreadable config files (`~/conductor/workspaces/dotfiles/petra/...` and `~/Desktop/mise.toml`), but completed the relevant Executor cleanup.
