### PR TITLE
chore(nix): adopt Determinate Nix 3.20 maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ darwin-rebuild switch --flake ~/dotfiles/nix-darwin#default
 nix run home-manager -- switch --flake ~/dotfiles/home-manager
 ```
 
+#### Nix Maintenance
+
+```bash
+# Enable repo-managed Determinate Nix custom warnings
+~/dotfiles/scripts/configure-nix-custom.sh
+
+# Clean old Nix generations, collect garbage, and compact Nix caches
+~/dotfiles/scripts/cleanup.sh
+```
+
 #### Manage Personal Configs (via Chezmoi)
 
 ```bash

--- a/home-manager/flake.lock
+++ b/home-manager/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764952935,
-        "narHash": "sha256-cRPB2zESVMjIGxJ49qj4t4qnT0ae44E+fS/mkfOS/BY=",
+        "lastModified": 1779213149,
+        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "519828bf1c97f8bc2ed2d3b79214067047d3c67d",
+        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764667669,
-        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "418468ac9527e799809c900eda37cbff999199b6",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1763638478,
-        "narHash": "sha256-n/IMowE9S23ovmTkKX7KhxXC2Yq41EAVFR2FBIXPcT8=",
+        "lastModified": 1778427648,
+        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "fbfdbaba008189499958a7aeb1e2c36ab10c067d",
+        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.0.3",
+        "ref": "5.1.11",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768271922,
-        "narHash": "sha256-zmFw7AtcmfMxW3vR7AiGeQQeHhdrd2x7a3hxzd6vJYI=",
+        "lastModified": 1779213149,
+        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fbd566923adcfa67be512a14a79467e2ab8a5777",
+        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1768312508,
-        "narHash": "sha256-P/3rGNB7IXJAeJK0yG0HxJd6HwzROxdVERFnhu6JHik=",
+        "lastModified": 1779283011,
+        "narHash": "sha256-t+yoQDd9lqfulhhtfWurFy8vntSD4/ygLo2NvJWCdXI=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "31bf713629bacd8ed5e4bff0850ef8665bb5cb93",
+        "rev": "2ea54578de93d08d080ee90cb47ebaa57ca92f90",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1768310125,
-        "narHash": "sha256-VRFQQhImGOZjG0CTyzeYkGPkFeTKQ2mzKRsepuVXEiM=",
+        "lastModified": 1779283693,
+        "narHash": "sha256-JatKjr+HttK1ZyftjthqmxZ5KQLt4kxNB/jxndL8oDw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "1ea2d54739ca22ff94375c96160e948dbbc00aad",
+        "rev": "269cbb28ce5bd15bafc320bbafcf2c8942e1f618",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     "homebrew-replicate": {
       "flake": false,
       "locked": {
-        "lastModified": 1733247456,
-        "narHash": "sha256-Fof2QUF+nj/OUw2UCjD/YBY74vFk7BLXER8w20eZ+xs=",
+        "lastModified": 1779231794,
+        "narHash": "sha256-Cr/vmprp4Aj4zV5RRqqg4h25CsFn8GeDKlkmSSkd4Ic=",
         "owner": "replicate",
         "repo": "homebrew-tap",
-        "rev": "fbbd779e415bf2f6aa7f3ee46a5fae9138b9638c",
+        "rev": "6df631f1673c4c7464b45417883c4986f26d7dc7",
         "type": "github"
       },
       "original": {
@@ -92,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768220509,
-        "narHash": "sha256-8wMrJP/Xk5Dkm0TxzaERLt3eGFEhHTWaJKUpK3AoL4o=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "7b1d394e7d9112d4060e12ef3271b38a7c43e83b",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1764473698,
-        "narHash": "sha256-C91gPgv6udN5WuIZWNehp8qdLqlrzX6iF/YyboOj6XI=",
+        "lastModified": 1778851564,
+        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "6a8ab60bfd66154feeaa1021fc3b32684814a62a",
+        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768178648,
-        "narHash": "sha256-kz/F6mhESPvU1diB7tOM3nLcBfQe7GU7GQCymRlTi/s=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3fbab70c6e69c87ea2b6e48aa6629da2aa6a23b0",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -10,6 +10,7 @@ configurations. Scripts are **idempotent** and **non-destructive**.
 | File           | Purpose                               |
 | -------------- | ------------------------------------- |
 | `bootstrap.sh` | First-time setup for new machines     |
+| `configure-nix-custom.sh` | Machine-local Determinate Nix custom settings |
 | `executor/common.sh` | Shared constants and helpers for executor automation |
 | `executor/doctor.sh` | Safe Executor daemon/process/keychain diagnostics |
 | `executor/launchd-daemon.sh` | Run the shared Executor daemon under launchd |
@@ -17,7 +18,7 @@ configurations. Scripts are **idempotent** and **non-destructive**.
 | `executor/status.sh` | Print executor runtime + source inventory |
 | `update.sh`       | Pull latest changes and apply configs |
 | `update-tools.sh` | Upgrade Mise tools and Claude Code     |
-| `cleanup.sh`      | Nix store maintenance and GC            |
+| `cleanup.sh`      | Nix store/cache maintenance and GC      |
 
 ## BOOTSTRAP SEQUENCE
 
@@ -227,8 +228,9 @@ apply` when an intentional launchd reload is needed.
 
 ## CLEANUP SCRIPT
 
-The `cleanup.sh` script frees disk space by removing old Nix generations and
-garbage collecting unreferenced store paths.
+The `cleanup.sh` script frees disk space by removing old Nix generations,
+garbage collecting unreferenced store paths, and maintaining user-writable Nix
+caches.
 
 **What it cleans:**
 
@@ -238,6 +240,8 @@ garbage collecting unreferenced store paths.
 | home-manager generations  | `nix-env --delete-generations old --profile ~/.local/state/nix/profiles/home-manager` |
 | user profile generations  | `nix-env --delete-generations old`                                                    |
 | unreferenced store paths  | `nix-collect-garbage -d`                                                              |
+| historical tarball cache  | `rm -rf ~/.cache/nix/tarball-cache`                                                   |
+| tarball-cache-v2          | `git -C ~/.cache/nix/tarball-cache-v2 multi-pack-index ...`                           |
 
 **When to run:**
 
@@ -251,6 +255,27 @@ rollback to previous configurations. If you want to keep recent generations:
 ```bash
 # Keep last 3 generations instead of just current
 sudo nix-env --delete-generations +3 --profile /nix/var/nix/profiles/system
+```
+
+## DETERMINATE NIX CUSTOM CONFIG
+
+Determinate owns `/etc/nix/nix.conf`; do not edit it. User-managed Nix settings
+belong in `/etc/nix/nix.custom.conf`, which Determinate includes from the main
+config.
+
+Run `scripts/configure-nix-custom.sh` to install the repo's managed custom block.
+The script currently enables Nix 2.34 literal diagnostics as warnings:
+
+```bash
+lint-url-literals = warn
+lint-short-path-literals = warn
+lint-absolute-path-literals = warn
+```
+
+Preview the exact change with:
+
+```bash
+scripts/configure-nix-custom.sh --check
 ```
 
 ## DEBUGGING

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
-# Nix store cleanup and maintenance
+# Nix store/cache cleanup and maintenance
 #
 # Run periodically to free disk space by removing old generations
-# and garbage collecting unreferenced store paths.
+# garbage collecting unreferenced store paths, and compacting Nix caches.
 
 set -euo pipefail
 
 echo "=== Nix Store Cleanup ==="
 echo "Before:"
 du -sh /nix/store
+du -sh "$HOME/.cache/nix" 2>/dev/null || true
 
 echo ""
 echo "Deleting old generations..."
@@ -34,6 +35,28 @@ echo "Running garbage collection..."
 nix-collect-garbage -d
 
 echo ""
+echo "Cleaning Nix tarball caches..."
+tarball_cache="$HOME/.cache/nix/tarball-cache"
+tarball_cache_v2="$HOME/.cache/nix/tarball-cache-v2"
+
+if [[ -d "$tarball_cache" ]]; then
+    echo "  - removing historical tarball-cache"
+    rm -rf "$tarball_cache"
+fi
+
+if [[ -d "$tarball_cache_v2/objects" ]]; then
+    if command -v git >/dev/null 2>&1; then
+        echo "  - compacting tarball-cache-v2"
+        git -C "$tarball_cache_v2" multi-pack-index write
+        git -C "$tarball_cache_v2" multi-pack-index repack
+        git -C "$tarball_cache_v2" multi-pack-index expire
+    else
+        echo "  - git not found; skipping tarball-cache-v2 compaction"
+    fi
+fi
+
+echo ""
 echo "=== Cleanup Complete ==="
 echo "After:"
 du -sh /nix/store
+du -sh "$HOME/.cache/nix" 2>/dev/null || true

--- a/scripts/configure-nix-custom.sh
+++ b/scripts/configure-nix-custom.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Configure machine-local Determinate Nix settings.
+#
+# Determinate owns /etc/nix/nix.conf and includes /etc/nix/nix.custom.conf for
+# user-managed settings. This script updates only a marked block in that custom
+# file.
+
+set -euo pipefail
+
+CONFIG_FILE="${NIX_CUSTOM_CONF:-/etc/nix/nix.custom.conf}"
+BEGIN_MARKER="# BEGIN dotfiles Determinate Nix 3.20 settings"
+END_MARKER="# END dotfiles Determinate Nix 3.20 settings"
+
+tmp_existing="$(mktemp)"
+tmp_next="$(mktemp)"
+cleanup() {
+    rm -f "$tmp_existing" "$tmp_next"
+}
+trap cleanup EXIT
+
+if [[ -f "$CONFIG_FILE" ]]; then
+    awk -v begin="$BEGIN_MARKER" -v end="$END_MARKER" '
+        $0 == begin { skip = 1; next }
+        $0 == end { skip = 0; next }
+        !skip { print }
+    ' "$CONFIG_FILE" > "$tmp_existing"
+else
+    : > "$tmp_existing"
+fi
+
+{
+    sed '${/^$/d;}' "$tmp_existing"
+    printf '\n%s\n' "$BEGIN_MARKER"
+    printf '# Warn on discouraged Nix literals without breaking existing flakes.\n'
+    printf 'lint-url-literals = warn\n'
+    printf 'lint-short-path-literals = warn\n'
+    printf 'lint-absolute-path-literals = warn\n'
+    printf '%s\n' "$END_MARKER"
+} > "$tmp_next"
+
+if [[ "${1:-}" == "--check" ]]; then
+    if [[ -f "$CONFIG_FILE" ]]; then
+        diff -u "$CONFIG_FILE" "$tmp_next" || true
+    else
+        cat "$tmp_next"
+    fi
+    exit 0
+fi
+
+root_group="$(id -gn 0 2>/dev/null || echo root)"
+sudo install -m 0644 -o root -g "$root_group" "$tmp_next" "$CONFIG_FILE"
+
+echo "Updated $CONFIG_FILE"
+echo "Verify with: nix config show | rg 'lint-(url|short|absolute)-path-literals'"


### PR DESCRIPTION
## Summary
- update nix-darwin and standalone Home Manager flake locks
- add a helper for repo-managed Determinate Nix custom lint warnings in /etc/nix/nix.custom.conf
- extend cleanup to remove the historical Nix tarball cache and compact tarball-cache-v2
- document the new Nix maintenance commands

## Verification
- bash -n scripts/cleanup.sh scripts/configure-nix-custom.sh
- scripts/configure-nix-custom.sh --check
- nix flake check --no-build ./nix-darwin
- nix flake check --no-build ./home-manager
- darwin-rebuild build --flake ./nix-darwin#kchen
- nix build ./home-manager#homeConfigurations.kchen.activationPackage --no-link
- git diff --check
- nix shell nixpkgs#shellcheck -c shellcheck scripts/cleanup.sh scripts/configure-nix-custom.sh