### PR TITLE
feat(executor): prefer Desktop MCP endpoint

### DIFF
--- a/chezmoi/dot_codex/modify_private_config.toml.tmpl
+++ b/chezmoi/dot_codex/modify_private_config.toml.tmpl
@@ -17,11 +17,17 @@ path = Path(sys.argv[1])
 text = path.read_text()
 
 block = '''[mcp_servers.executor]
+url = "http://127.0.0.1:4789/mcp"
+
+[mcp_servers.executor-cloud]
 url = "https://executor.sh/mcp"
 
 '''
 
-pattern = re.compile(r'(?ms)^\[mcp_servers\.executor\]\n.*?(?=^\[|\Z)')
+pattern = re.compile(
+    r'(?ms)^\[mcp_servers\.executor\]\n.*?(?=^\[|\Z)'
+    r'(?:^\[mcp_servers\.executor-(?:desktop|cloud)\]\n.*?(?=^\[|\Z))*'
+)
 
 if text.strip():
     if pattern.search(text):

--- a/chezmoi/dot_config/crush/crush.json
+++ b/chezmoi/dot_config/crush/crush.json
@@ -53,6 +53,11 @@
   "mcp": {
     "executor": {
       "type": "http",
+      "url": "http://127.0.0.1:4789/mcp",
+      "timeout": 120
+    },
+    "executor-cloud": {
+      "type": "http",
       "url": "https://executor.sh/mcp",
       "timeout": 120
     }

--- a/chezmoi/dot_config/opencode/opencode.json
+++ b/chezmoi/dot_config/opencode/opencode.json
@@ -12,6 +12,11 @@
   "mcp": {
     "executor": {
       "type": "remote",
+      "url": "http://127.0.0.1:4789/mcp",
+      "enabled": true
+    },
+    "executor-cloud": {
+      "type": "remote",
       "url": "https://executor.sh/mcp",
       "enabled": true
     }

--- a/chezmoi/modify_dot_claude.json.tmpl
+++ b/chezmoi/modify_dot_claude.json.tmpl
@@ -5,10 +5,15 @@
 set -euo pipefail
 
 # Define the MCP servers configuration.
-# Use Executor Cloud as the shared MCP gateway.
+# Use Executor Desktop as the default MCP gateway and keep Cloud available as
+# an explicit fallback.
 MCP_CONFIG='{
   "mcpServers": {
     "executor": {
+      "type": "http",
+      "url": "http://127.0.0.1:4789/mcp"
+    },
+    "executor-cloud": {
       "type": "http",
       "url": "https://executor.sh/mcp"
     }

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -10,9 +10,12 @@ an optional plugin manifest, not the source catalog.
 
 ## Client Wiring
 
-Codex, Claude, OpenCode, and Crush all use Executor Cloud:
+Codex, Claude, OpenCode, and Crush are wired to both Executor endpoints.
+Desktop is the default `executor` entry, and Cloud is available as
+`executor-cloud`:
 
-- `https://executor.sh/mcp`
+- `executor`: `http://127.0.0.1:4789/mcp`
+- `executor-cloud`: `https://executor.sh/mcp`
 
 Desktop owns its own local sidecar lifecycle when it is used interactively; this
 repo should not start a second background Executor runtime against the same
@@ -44,7 +47,7 @@ secrets, OAuth connections, and policies through Executor Cloud/Desktop.
 
 Chezmoi should manage the pieces that are stable text config:
 
-- agent client wiring that points at `https://executor.sh/mcp`
+- agent client wiring that points at Executor Cloud and Desktop MCP endpoints
 - operator docs
 
 Chezmoi should not own `~/.executor/executor.jsonc` wholesale. Local Desktop
@@ -78,9 +81,9 @@ but Executor sources should not rely on committed env wiring.
 
 ## Project Scopes
 
-Global clients use Executor Cloud. Project repos should move project-specific
-tools and policies into project/workspace scopes instead of adding them to
-global dotfiles.
+Global clients use shared Executor endpoints. Project repos should move
+project-specific tools and policies into project/workspace scopes instead of
+adding them to global dotfiles.
 
 Examples of project-specific sources that should not live in global dotfiles:
 
@@ -162,7 +165,8 @@ Suggested personal Cloud baseline:
 ## Manual Operations
 
 ```bash
-npx add-mcp https://executor.sh/mcp --transport http --name executor
+npx add-mcp http://127.0.0.1:4789/mcp --transport http --name executor
+npx add-mcp https://executor.sh/mcp --transport http --name executor-cloud
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Configures Claude, Codex, OpenCode, and Crush so the default executor MCP entry points to Executor Desktop at http://127.0.0.1:4789/mcp. Keeps Executor Cloud available through a separate executor-cloud entry at https://executor.sh/mcp. Updates the Executor docs and Codex config modifier to preserve the new names and migrate older executor-desktop wiring.