### PR TITLE
chore(mise): upgrade executor to 1.4.33

### DIFF
--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -27,7 +27,7 @@ bun = "1.3.11"
 "npm:@google/gemini-cli" = "0.34.0"
 "npm:@openai/codex" = "0.116.0"
 "npm:markit-ai" = "0.5.0"       # exception: first npm release was 2026-03-25, so no 7-day-old version exists yet
-"npm:executor" = "1.4.31"       # desktop release + DB-owned source state; keep pinned across schema migrations
+"npm:executor" = "1.4.33"       # desktop release + DB-owned source state; keep pinned across schema migrations
 "npm:agent-browser" = "0.22.0"
 "npm:hunkdiff" = "0.12.0"       # review-first terminal diff viewer
 

--- a/chezmoi/dot_config/mise/mise.lock
+++ b/chezmoi/dot_config/mise/mise.lock
@@ -609,7 +609,7 @@ version = "0.22.0"
 backend = "npm:agent-browser"
 
 [[tools."npm:executor"]]
-version = "1.4.31"
+version = "1.4.33"
 backend = "npm:executor"
 
 [[tools."npm:hunkdiff"]]

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -4,7 +4,7 @@ Executor is the shared tool catalog for agent clients on this machine.
 Dotfiles manage how clients connect to Executor; Executor owns live runtime
 state, hosted sources, credentials, and policies.
 
-This repo pins Executor to `1.4.31`. Executor `1.4.28` was the first local
+This repo pins Executor to `1.4.33`. Executor `1.4.28` was the first local
 release where source state is clearly database-owned again. `executor.jsonc` is
 an optional plugin manifest, not the source catalog.
 


### PR DESCRIPTION
## Summary
- Bump the Mise-managed `npm:executor` pin from `1.4.31` to `1.4.33`.
- Keep `mise.lock` and `docs/executor.md` aligned with the new version.
- Pick up upstream auth recovery and MCP output-schema fixes called out in the [Executor 1.4.33 release notes][executor-1-4-33] without changing the dotfiles/Executor ownership boundary.

## Verification
- `yq -p toml '.tools."npm:executor"' chezmoi/dot_config/mise/config.toml`
- `yq -p toml '.tools."npm:executor"[0].version' chezmoi/dot_config/mise/mise.lock`
- `npm view executor version --json`

[executor-1-4-33]: https://github.com/RhysSullivan/executor/releases/tag/v1.4.33
