### PR TITLE
chore(mise): harden tool install resolution

### DIFF
--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -5,6 +5,17 @@
 [settings]
 # Save exact versions by default when adding tools with `mise use`.
 pin = true
+# Keep the generated lockfile active, limit future auto-locking to this Mac's
+# platform, and re-check available provenance during installs.
+lockfile = true
+lockfile_platforms = ["macos-arm64"]
+locked_verify_provenance = true
+# Avoid resolving brand-new releases before they have had basic ecosystem soak
+# time. This also applies to supported package-manager backends during install.
+minimum_release_age = "7d"
+# Do not enable locked=true yet: npm/cargo/go backends are version-only in
+# mise.lock, so strict URL-locked installs would fail until those tools move to
+# aqua/github/http release-asset backends.
 
 [tools]
 

--- a/scripts/update-tools.sh
+++ b/scripts/update-tools.sh
@@ -16,6 +16,9 @@ if command -v mise >/dev/null 2>&1; then
     mise upgrade
   fi
 
+  echo "Refreshing Mise lockfile metadata..."
+  mise lock --global --platform macos-arm64
+
   echo "Pruning unused Mise versions..."
   mise prune --yes
 


### PR DESCRIPTION
## Summary
- Enable Mise [lockfile][mise-lockfile] use, install-time [provenance rechecks][mise-provenance], and 7-day [release-age filtering][mise-release-age].
- Scope future automatic lockfile metadata updates to `macos-arm64` using documented [lockfile platform filtering][mise-lockfile-platforms].
- Refresh global lock metadata after tool upgrades while explicitly deferring `locked = true` because Mise documents npm/cargo/go backends as weaker than URL/checksum-capable [aqua/github release-asset backends][mise-registry-backends].

## Verification
- `yq -p toml '.settings' chezmoi/dot_config/mise/config.toml`
- `bash -n scripts/update-tools.sh`
- `MISE_GLOBAL_CONFIG_FILE=$PWD/chezmoi/dot_config/mise/config.toml mise settings ls | rg -n "lockfile|locked_verify_provenance|minimum_release_age|pin"`

[mise-lockfile]: https://mise.jdx.dev/dev-tools/mise-lock.html
[mise-provenance]: https://mise.jdx.dev/dev-tools/mise-lock.html#provenance-verification
[mise-release-age]: https://mise.jdx.dev/dev-tools/mise-lock.html#minimum-release-age
[mise-lockfile-platforms]: https://mise.jdx.dev/configuration/settings.html#lockfile-platforms
[mise-registry-backends]: https://mise.jdx.dev/registry.html#backends
