### PR TITLE
feat(skills): add parallel agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Nix build results
 result
 result-*
+!chezmoi/dot_agents/skills/result/
+!chezmoi/dot_agents/skills/result/**
 
 # Home Manager generations
 *.backup

--- a/chezmoi/dot_agents/skills/README.md
+++ b/chezmoi/dot_agents/skills/README.md
@@ -1,0 +1,35 @@
+# Agent Skills
+
+## Layout
+
+Keep skills flat as direct children of this directory.
+
+## Parallel
+
+From https://github.com/parallel-web/parallel-agent-skills.
+
+Web search, extraction, deep research, enrichment, entity discovery, monitoring,
+CLI setup, and research task `status`/`result`.
+
+## Firecrawl
+
+From https://github.com/firecrawl/cli/tree/main/skills.
+
+Web search, scraping, crawling, mapping, parsing, downloading, interaction,
+monitoring, agent, and CLI skills.
+
+## ast-grep
+
+From https://github.com/ast-grep/agent-skill.
+
+Structural code search with ast-grep.
+
+## nia
+
+From https://github.com/nozomio-labs/nia-skill.
+
+Nia search and connector workflows.
+
+## Custom
+
+Everything else is custom-made.

--- a/chezmoi/dot_agents/skills/parallel-cli-setup/SKILL.md
+++ b/chezmoi/dot_agents/skills/parallel-cli-setup/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: parallel-cli-setup
+description: Set up and maintain the Parallel CLI (install, auth, balance, skills install)
+user-invocable: true
+allowed-tools: Bash(command:*), Bash(brew:*), Bash(uv:*), Bash(npm:*), Bash(pipx:*), Bash(curl:*), Bash(rm:*), Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# Parallel CLI Setup
+
+Set up or maintain `parallel-cli` with minimal friction. If you are running this prompt, your goal is to follow the instructions below and set up `parallel-cli` for the user so that they can execute searches, run extracts, deep research, etc.
+
+## Step 1: Install or upgrade the CLI
+
+Check whether the CLI exists:
+
+```bash
+command -v parallel-cli
+```
+
+If missing, install with any of these methods:
+
+1. macOS only: `brew install parallel-web/tap/parallel-cli`
+2. Linux/macOS/Windows (uv): `uv tool install "parallel-web-tools[cli]"`
+3. Linux/macOS/Windows (npm): `npm install -g parallel-web-cli`
+4. Linux/macOS/Windows (pipx): `pipx install "parallel-web-tools[cli]" && pipx ensurepath`
+
+When `parallel-cli` is present, require version `>=0.4.0`. If older, identify the install method before advising an update. Use `command -v parallel-cli`, then inspect `readlink "$(command -v parallel-cli)"` if it is a symlink. Paths under `~/.local/share/uv/
+  tools/` indicate `uv tool install`; paths under `~/.local/share/parallel-cli/` indicate the standalone installer.
+
+Upgrade commands (choose based on how it was installed):
+
+- standalone: `parallel-cli update`
+- uv: `uv tool upgrade parallel-web-tools[cli]`
+- pipx: `pipx upgrade parallel-web-tools[cli]`
+- npm: `npm update -g parallel-web-cli`
+- homebrew: `brew update && brew upgrade parallel-web/tap/parallel-cli`
+
+## Step 2: Authenticate
+
+Check auth status:
+
+```bash
+parallel-cli auth --json
+```
+
+You will get a response like:
+
+```json
+{
+  "authenticated": true,
+  "method": "oauth",
+  "env_var_set": false,
+  "has_stored_credentials": true,
+  "stored_overridden_by_env": false,
+  "token_file": "xxx",
+  "version": 1,
+  "selected_org_id": "legacy",
+  "selected_org_name": null,
+  "has_control_api_tokens": false
+}
+```
+
+If `authenticated` is `false` or `selected_org_id` is `legacy`, prompt the user to log in:
+
+```bash
+parallel-cli login --json
+```
+
+If this is a headless session, append `--no-browser`.
+
+This triggers device OAuth. The user will be prompted to go to a web browser and input the code the CLI outputs.
+
+When invoking from an agent harness, prefer streaming stdout via a Monitor-style tool over blocking on completion.
+
+The output will look like:
+
+```json
+{"event": "auth_start"}
+{"event": "device_code", "verification_uri": "http://localhost:3000/getServiceKeys/device", "verification_uri_complete": "http://localhost:3000/getServiceKeys/device?user_code=CHQX-NQKP&onboard_variant=agent", "user_code": "CHQX-NQKP", "expires_in": 600, "browser_open_attempted": true, "browser_opened": true}
+{"event": "auth_waiting"}
+{"event": "auth_success"}
+```
+
+`{"event": "auth_success"}` is emitted only after the user has successfully authorized the CLI. Otherwise it blocks at `{"event": "auth_waiting"}`.
+
+## Step 3: Check balance
+
+After authentication, check the current balance:
+
+```bash
+parallel-cli balance get
+```
+
+If zero, prompt the user to add balance:
+
+```bash
+parallel-cli balance add <AMOUNT_IN_CENTS>
+```
+
+Make it clear that a payment method should have been added to the organization. If not, the user can go to <https://platform.parallel.ai/settings> to add one.
+
+## Step 4: Install the Parallel skills
+
+Install the skills for the user:
+
+```bash
+parallel-cli skills install
+```
+
+The user may need to restart their agent if it doesn't support hot reloading (e.g. Claude).
+
+## Step 5: Suggest a first run
+
+Prompt the user to use the newly installed skills in `~/.agents/skills` to run a search or extract right away. Suggest one of:
+
+- `/parallel:parallel-web-search <query>` — fast web search
+- `/parallel:parallel-web-extract <url>` — extract content from a URL
+- `/parallel:parallel-deep-research <topic>` — comprehensive research
+- `/parallel:parallel-data-enrichment <list>` — enrich a list of entities

--- a/chezmoi/dot_agents/skills/parallel-data-enrichment/SKILL.md
+++ b/chezmoi/dot_agents/skills/parallel-data-enrichment/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: parallel-data-enrichment
+description: "Bulk data enrichment. Adds web-sourced fields (CEO names, funding, contact info) to lists of companies, people, or products. Use for enriching CSV files or inline data. Supports multi-turn: pass --previous-interaction-id from a prior research task to carry context forward."
+user-invocable: true
+argument-hint: <file or entities> with <fields to add>
+compatibility: Requires parallel-cli and internet access.
+allowed-tools: Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# Data Enrichment
+
+Enrich: $ARGUMENTS
+
+## Before starting
+
+Inform the user that enrichment may take several minutes depending on the number of rows and fields requested.
+
+## Optional: Suggest output columns
+
+If the user gave a vague intent ("enrich these companies with useful info") and you're not sure what columns to add, ask the API for a suggestion before kicking off the run:
+
+```bash
+parallel-cli enrich suggest "Find CEO and recent funding info" --json
+```
+
+The response is an envelope: `{title, processor, enriched_columns, warnings}`. Extract just the **`enriched_columns` array** (not the whole envelope) and pass it as the value of `--enriched-columns` on `enrich run`, **in place of `--intent`** — the two flags are alternative ways to specify what to enrich, not combined. If `suggest` returned a `processor`, pass it through explicitly via `--processor` on the `run` call (it's a tuned recommendation for the schema). Skip this whole section if the user already specified the fields they want.
+
+> `enrich suggest` requires `parallel-cli` ≥ 0.3.0. If it errors with anything resembling `no such command` / `No such command` / `unknown command`, **do not bail** — skip the suggestion step, fall through to step 1 with `--intent`, complete the run, and mention `parallel-cli update` (or `pipx upgrade parallel-web-tools`) in the final response so the user picks up the feature next time.
+
+## Step 1: Start the enrichment
+
+Use ONE of these command patterns (substitute user's actual data):
+
+For inline data:
+
+```bash
+parallel-cli enrich run --data '[{"company": "Google"}, {"company": "Microsoft"}]' --intent "CEO name and founding year" --target "output.csv" --no-wait --json
+```
+
+For CSV file:
+
+```bash
+parallel-cli enrich run --source-type csv --source "input.csv" --target "output.csv" --source-columns '[{"name": "company", "description": "Company name"}]' --intent "CEO name and founding year" --no-wait --json
+```
+
+If this is a **follow-up** to a previous research task and you have its `interaction_id`, add context chaining:
+
+```bash
+parallel-cli enrich run --data '...' --intent "..." --target "output.csv" --no-wait --json --previous-interaction-id "$INTERACTION_ID"
+```
+
+The enrichment will run with the full context of that prior research — so you can enrich entities discovered earlier without restating what was already found. Note: enrichment does **not** itself produce a new `interaction_id`, so you cannot chain a further follow-up off of an enrichment.
+
+**IMPORTANT:** Always include `--no-wait` so the command returns immediately instead of blocking.
+
+Parse the `--json` output to extract `taskgroup_id` and `url`. The output is `{taskgroup_id, url, num_runs}` — there is no `interaction_id` field, do not look for one. Immediately tell the user:
+
+- Enrichment has been kicked off
+- The monitoring URL where they can track progress
+
+Tell them they can background the polling step to continue working while it runs.
+
+## Step 2: Poll for results
+
+Pick a concrete output path (e.g., `/tmp/enrichment-acme.json`). Note: the file is JSON regardless of the extension you choose — it's an array of `{input, output}` objects, not a CSV. Name it `.json` to avoid confusing yourself or the user.
+
+```bash
+parallel-cli enrich poll "$TASKGROUP_ID" --timeout 540 --output "/tmp/enrichment-<descriptive-name>.json"
+```
+
+Important:
+
+- Use `--timeout 540` (9 minutes) to stay within tool execution limits
+- The `--target` from step 1 is unused in `--no-wait` mode — only `--output` here determines where results are saved, and the file is always JSON
+
+### If the poll times out
+
+Enrichment of large datasets can take longer than 9 minutes. If the poll exits without completing:
+
+1. Tell the user the enrichment is still running server-side
+2. Re-run the same `parallel-cli enrich poll` command to continue waiting
+
+## Response format
+
+**After step 1:** Share the monitoring URL (for tracking progress).
+
+**After step 2:**
+
+1. Report number of rows enriched
+2. Preview first few rows from the output file (it's a JSON array of `{input, output}` objects)
+3. Tell the user the full path to the output file
+
+Do NOT re-share the monitoring URL after completion — the results are in the output file.
+
+## Setup
+
+If `parallel-cli` is not found, install and authenticate:
+
+```bash
+/parallel:parallel-cli-setup
+```
+
+If any `parallel-cli enrich` command returns `403`, tell the user balance is likely required. Offer to run `parallel-cli balance get`, and if needed ask for explicit confirmation before running `parallel-cli balance add <amount_cents>`. Then retry the original enrichment command.

--- a/chezmoi/dot_agents/skills/parallel-deep-research/SKILL.md
+++ b/chezmoi/dot_agents/skills/parallel-deep-research/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: parallel-deep-research
+description: "ONLY use when user explicitly says 'deep research', 'exhaustive', 'comprehensive report', or 'thorough investigation'. Slower and more expensive than parallel-web-search. For normal research/lookup requests, use parallel-web-search instead. Supports multi-turn: pass --previous-interaction-id from a prior research or enrichment to continue with context."
+user-invocable: true
+argument-hint: <topic>
+compatibility: Requires parallel-cli >= 0.3.0 and internet access.
+allowed-tools: Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# Deep Research
+
+Research topic: $ARGUMENTS
+
+> Requires `parallel-cli` ≥ 0.3.0. If any command below errors with `no such option`, `no such command`, or `unrecognized arguments`, the user is on an older CLI. Tell them to run `parallel-cli update` (or `pipx upgrade parallel-web-tools` if installed via pipx), then retry.
+
+## When to use (vs parallel-web-search)
+
+ONLY use this skill when the user explicitly requests deep/exhaustive research. Deep research is 10-100x slower and more expensive than parallel-web-search. For normal "research X" requests, quick lookups, or fact-checking, use **parallel-web-search** instead.
+
+## Step 1: Start the research
+
+Choose a descriptive filename based on the topic (e.g., `ai-chip-market-2026`, `react-vs-vue-comparison`). Use lowercase with hyphens, no spaces. Reuse this base name in step 2 as `-o "$FILENAME"`.
+
+```bash
+parallel-cli research run "$ARGUMENTS" --processor pro-fast --text --no-wait --json
+```
+
+The `--text` flag tells the API to return a markdown report (with inline citations) when the task completes, instead of the default structured JSON. Use it for narrative/report-style requests, which is what most users want from "deep research." Drop `--text` if the user explicitly wants structured JSON output.
+
+Optional with `--text`: pass `--text-description "Keep under 1500 words, focus on M&A activity"` to steer length, format, or focus.
+
+If this is a **follow-up** to a previous research or enrichment task where you know the `interaction_id`, add context chaining:
+
+```bash
+parallel-cli research run "$ARGUMENTS" --processor lite-fast --text --no-wait --json --previous-interaction-id "$INTERACTION_ID"
+```
+
+By chaining `interaction_id` values across requests, each follow-up question automatically has the full context of prior turns — so you can drill deeper without restating what was already researched. Use a lighter processor (`lite-fast` or `base-fast`) for follow-ups since the heavy lifting was done in the initial turn.
+
+This returns instantly. Do NOT omit `--no-wait` — without it the command blocks for minutes and will time out.
+
+Processor options (choose based on user request):
+
+| Processor | Expected latency | Use when |
+|-----------|-----------------|----------|
+| `lite-fast` | 10–60s | Quick lookups, follow-ups |
+| `base-fast` | 15–100s | Simple questions |
+| `core-fast` | 1–5 min | Moderate research |
+| `pro-fast` | 2–10 min | **Default** — exploratory research, good depth/speed balance |
+| `ultra-fast` | 5–25 min | Multi-source deep research (~2× cost) |
+| `ultra2x-fast` / `ultra4x-fast` / `ultra8x-fast` | up to 2 hr | Hardest questions, only when explicitly requested |
+
+Notes on the `-fast` suffix: `-fast` tiers use cached web data and are quicker. The non-fast variants (`pro`, `ultra`, etc.) re-fetch fresher data — slower but better for very recent events. Default to `-fast` unless the user specifically asks about news from the last day or two.
+
+Run `parallel-cli research processors` to see the full list with latencies.
+
+Parse the JSON output to extract the `run_id`, `interaction_id`, and monitoring URL. Immediately tell the user:
+
+- Deep research has been kicked off
+- The expected latency for the processor tier chosen (from the table above)
+- The monitoring URL where they can track progress
+
+Tell them they can background the polling step to continue working while it runs.
+
+## Step 2: Poll for results
+
+```bash
+parallel-cli research poll "$RUN_ID" -o "$FILENAME" --timeout 540
+```
+
+Important:
+
+- Use `--timeout 540` (9 minutes) to stay within tool execution limits
+- Do NOT pass `--json` — the full output is large and will flood context. The `-o` flag writes results to files instead.
+- With `-o "$FILENAME"`:
+  - `$FILENAME.json` is always written (metadata + basis)
+  - `$FILENAME.md` is written **only if step 1 used `--text`** (markdown report)
+- The poll command prints an **executive summary** to stdout when the research completes. Share this executive summary with the user — it gives them a quick overview without having to open the files.
+- Pass `--force` if re-polling and you want to overwrite existing files
+
+### If the poll times out
+
+Higher processor tiers can take longer than 9 minutes. If the poll exits without completing:
+
+1. Tell the user the research is still running server-side
+2. Re-run the same `parallel-cli research poll` command to continue waiting
+
+## Response format
+
+**After step 1:** Share the monitoring URL (for tracking progress only — it is not the final report).
+
+**After step 2:**
+
+1. Share the **executive summary** that the poll command printed to stdout
+2. Tell the user the generated file paths:
+   - `$FILENAME.md` — formatted markdown report (if `--text` was used)
+   - `$FILENAME.json` — metadata and basis
+3. Share the `interaction_id` and tell the user they can ask follow-up questions that build on this research (e.g., "drill deeper into X" or "compare that to Y")
+
+Do NOT re-share the monitoring URL after completion — the results are in the files, not at that link.
+
+Ask the user if they would like to read through the files for more detail. Do NOT read the file contents into context unless the user asks.
+
+**Remember the `interaction_id`** — if the user asks a follow-up question that relates to this research, use it as `--previous-interaction-id` in the next research or enrichment command.
+
+## Setup
+
+If `parallel-cli` is not found, install and authenticate:
+
+```bash
+/parallel:parallel-cli-setup
+```
+
+If any `parallel-cli research` command returns `403`, tell the user balance is likely required. Offer to run `parallel-cli balance get`, and if needed ask for explicit confirmation before running `parallel-cli balance add <amount_cents>`. Then retry the original research command.

--- a/chezmoi/dot_agents/skills/parallel-findall/SKILL.md
+++ b/chezmoi/dot_agents/skills/parallel-findall/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: parallel-findall
+description: "Discover entities (companies, people, products, etc.) matching a natural-language description. Use when the user asks to 'find all X' or 'list every Y that…' — e.g., 'Find AI startups that raised Series A in 2026', 'List roofing companies in Charlotte NC', 'Show me YC W24 dev tools companies'. Different from web-search (which returns webpages) and deep-research (which returns a narrative report). Use this when the user wants a structured list of entities."
+user-invocable: true
+argument-hint: <objective describing entities to find>
+compatibility: Requires parallel-cli >= 0.6.0 and internet access.
+allowed-tools: Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# FindAll: Entity Discovery
+
+Find: $ARGUMENTS
+
+> Requires `parallel-cli` ≥ 0.6.0 (the `findall entity-search` command was added in 0.6.0; the broader `findall` command was added in 0.3.0). If either errors with `no such command` or similar, tell the user to run `parallel-cli update` (or `pipx upgrade parallel-web-tools` if installed via pipx), then retry.
+
+## When to use this skill
+
+Use FindAll when the user wants a **structured list of entities** matching a description, not webpages or a narrative answer.
+
+| User asks for… | Use |
+|---|---|
+| "Find all X that…" / "List every Y…" | **parallel-findall** (this skill) |
+| Webpage results / quick answers / current info | parallel-web-search |
+| Narrative report / analysis / "research X" | parallel-deep-research |
+| Add fields to a list you already have | parallel-data-enrichment |
+
+If the user already has a list and just wants to add fields, this is the wrong skill — use parallel-data-enrichment.
+
+FindAll has two paths: the comprehensive, asynchronous `findall run` (Steps 1–2) and the fast, synchronous `entity-search` (final section).
+
+- **`entity-search`** — very fast (few seconds), only supports people or company search. Supports a more limited set of query arguments.
+- **`findall run`** — Provides comprehensive coverage, complex, match conditions, exclusions, enrichment, citations, or a type other than people/companies.
+
+If it's ambiguous, ask the user which they'd prefer and offer a default. Remember entity search limits: companies/people only, no exclusions/generator/enrichment, and `entity_set_id` can't be used with `enrich`/`extend` (re-run via `findall run` if needed).
+
+Switch to `entity-search` **only when the user explicitly signals they want a fast, throwaway list**. `entity-search` is also strictly more limited: it only supports `companies` or `people` entity types, no exclusions, no generator choice, no enrichment, and the returned `entity_set_id` is **not** usable with `findall enrich`/`extend`. If you start there and the user later asks to enrich or extend, you'll have to re-run via `findall run`.
+
+## Step 1: Start the run
+
+```bash
+parallel-cli findall run "$ARGUMENTS" --no-wait --json
+```
+
+Defaults: generator `core`, match limit `10`. Stick with `core` unless the user has a reason to escalate:
+
+- `-g pro` — most thorough generator (slower, costlier). Use when the user asks for "comprehensive" coverage or matches are sparse on `core`
+- `-g base` — fastest, but **markedly lower quality**. Often returns query-echo entities (e.g., directory pages, the literal query string), entries with no URL, or category placeholders. Only use if the user explicitly asks for a quick scan and accepts noise; otherwise prefer `core`
+- `-n 50` — return up to 50 matched entities (5–1000 allowed)
+
+If the user wants to exclude known entities (e.g., "find competitors but not Google or OpenAI"):
+
+```bash
+parallel-cli findall run "$ARGUMENTS" --no-wait --json \
+    --exclude '[{"name":"Google","url":"google.com"},{"name":"OpenAI","url":"openai.com"}]'
+```
+
+Tip — preview the schema first if the objective is ambiguous: `parallel-cli findall ingest "$ARGUMENTS" --json` shows the entity type and match conditions the API inferred, so you can refine wording before paying for a run.
+
+Parse the JSON output to extract the `findall_id` and any monitoring URL. Tell the user:
+
+- A FindAll run has been started
+- Approximate cadence (minutes for `core`, longer for `pro`)
+- They can keep working while it runs
+
+## Step 2: Poll for results
+
+Choose a descriptive filename (e.g., `series-a-ai-2026`, `charlotte-roofers`). Use lowercase with hyphens, no spaces.
+
+```bash
+parallel-cli findall poll "$FINDALL_ID" -o "/tmp/$FILENAME.json" --timeout 540
+```
+
+Important:
+
+- Use `--timeout 540` (9 minutes) to stay within tool execution limits
+- Do NOT pass `--json` for large result sets — it will flood context. `-o` saves the full results to disk
+
+### If the poll times out
+
+Re-run the same `parallel-cli findall poll` command to continue waiting. Server-side the run continues regardless.
+
+## Response format
+
+Before presenting matches, **filter the results** for obvious noise:
+
+- Drop entries with empty/missing `url`
+- Drop entries whose `name` echoes the user's query (e.g., literal "YC W25 batch companies in developer tools") — those are search-result placeholders, not real entities
+- Drop entries whose `url` is a third-party directory or profile page rather than the entity's own domain. The URL should be something the entity itself owns (its product site, docs, or marketing site)
+
+If filtering removes a meaningful share of matches, mention this to the user and suggest re-running with `-g pro` or a higher `-n`.
+
+**Sanity-check `-g base` results.** The base generator can hallucinate categorical attributes (e.g., return a YC S22 company as a YC W25 match). The filter rules above only catch URL/name shape, not factual correctness. If the user's query has a falsifiable attribute (a specific batch, year, geography, etc.), spot-check the kept entries against the source URL and flag any that don't fit. Recommend re-running with `-g core` (or higher) if **either** multiple kept entries fail the spot-check **or** noise filtering dropped a meaningful share of the matched set (say, ≥40%) — both indicate `base` isn't producing reliable results for this query.
+
+Present the remaining (real) entities as a markdown table or list. Lead with the count, then list each entity with its name, URL, and a one-line description if available. Cite each entity with its source URL.
+
+Tell the user:
+
+- How many entities were matched (and how many were filtered as noise, if any)
+- The full results path (`/tmp/$FILENAME.json`)
+- That they can:
+  - Add fields to these results, e.g.:
+
+    ```bash
+    parallel-cli findall enrich $FINDALL_ID '{"properties":{"ceo":{"type":"string"},"employee_count":{"type":"number"}}}'
+    ```
+
+    The schema is a JSON Schema-style object with `properties` mapping field names → `{type, description?}`.
+  - Get more matches: `parallel-cli findall extend $FINDALL_ID 50`
+
+## Fast entity search
+
+**Use this path only when the user explicitly signals they want a quick/rough/preview list** — do not pick it just because the entity type happens to be `companies` or `people`.
+
+Synchronous call. No polling, no `findall_id`. Pick a descriptive `$FILENAME` (lowercase, hyphens, no spaces), as in Step 2.
+
+```bash
+parallel-cli findall entity-search "$ARGUMENTS" -t companies -n 25 -o "/tmp/$FILENAME.json"
+```
+
+Flags:
+
+- `-t companies|people` — entity type (required). The endpoint only supports these two; for anything else, use `findall run`
+- `-n 5..1000` — match limit (default `10`).
+- Do NOT pass `--json` for large result sets — it will flood context. `-o` saves the full results to disk
+
+Response shape:
+
+```json
+{ "entity_set_id": "entity_set_…", "entities": [ {"name": "...", "url": "...", "description": "..."},
+… ] }
+```
+
+Unlike the full path, the `url` returned by `entity-search` is usually a directory/profile link — expected, not noise. Don't drop them; only filter out entries with an empty `url` or a `name` that echoes the query.
+
+Present the kept entities as a markdown table or list, lead with the count, and cite each with its source URL. Tell the user:
+
+- How many entities came back (and how many were filtered as noise)
+- The full results path (`/tmp/$FILENAME.json`) if `-o` was used
+
+## Setup
+
+Requires `parallel-cli` (installed and authenticated). If `parallel-cli --version` fails, or if a later command fails with an authentication error, tell the user to see <https://docs.parallel.ai/integrations/cli> and stop.

--- a/chezmoi/dot_agents/skills/parallel-monitor/SKILL.md
+++ b/chezmoi/dot_agents/skills/parallel-monitor/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: parallel-monitor
+description: "Continuously track the web for changes on a recurring cadence. Use when the user asks to 'monitor', 'track changes to', 'watch', or 'alert me when' something on the web changes — e.g., 'Track price changes for iPhone 16', 'Alert me when Tesla files a new 8-K', 'Monitor competitor pricing pages weekly'. Also use to list, inspect, update, or delete existing monitors."
+user-invocable: true
+argument-hint: <create|list|events|get|update|simulate|event-group|delete> [args]
+compatibility: Requires parallel-cli >= 0.3.0 and internet access.
+allowed-tools: Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# Web Monitor
+
+Action: $ARGUMENTS
+
+> Requires `parallel-cli` ≥ 0.3.0 (the `monitor` command was added in 0.3.0). If `parallel-cli monitor` errors with `no such command` or similar, tell the user to run `parallel-cli update` (or `pipx upgrade parallel-web-tools` if installed via pipx), then retry.
+
+## What this skill does
+
+Monitors are long-running, server-side jobs that re-check the web on a cadence and emit events when something changes. Unlike search/research/findall (one-shot lookups), monitors persist until deleted and can optionally fire a webhook on each event.
+
+## Decide the action
+
+Parse the user's request and pick one:
+
+| Intent | Action |
+|---|---|
+| "Track / watch / monitor / alert me when X" | **create** |
+| "What am I monitoring?" / "List monitors" | **list** |
+| "What changed?" / "Show me events for monitor X" | **events** |
+| "Show monitor X" / "Get details for X" | **get** |
+| "Change cadence / query / webhook for X" | **update** |
+| "Test the webhook" / "Fire a test event" | **simulate** (requires a webhook on the monitor) |
+| "Show me the full payload for event group X" | **event-group** |
+| "Stop / delete monitor X" | **delete** (always confirm before deleting) |
+
+## Create a monitor
+
+```bash
+parallel-cli monitor create "<query>" --cadence daily --json
+```
+
+Cadence options: `hourly`, `daily` (default), `weekly`, `every_two_weeks`. Match cadence to how often the source actually changes — hourly for prices/news, weekly for filings/staffing.
+
+Optional flags:
+
+- `--webhook https://example.com/hook` — POST events to a URL as they happen
+- `--metadata '{"team":"competitive-intel"}'` — attach JSON metadata for your own bookkeeping
+- `--output-schema '<json>'` — structure the event payload (advanced)
+
+Parse the JSON to extract the `monitor_id`. Tell the user:
+
+- The monitor has been created with its ID
+- The cadence (so they know when to expect first event)
+- That events accumulate server-side — they can run `parallel-cli monitor events $MONITOR_ID` later to see what changed
+
+If they configured a webhook, suggest testing it:
+
+```bash
+parallel-cli monitor simulate "$MONITOR_ID"
+```
+
+`simulate` requires a webhook to be configured on the monitor. Without one it errors with `Webhook not configured for this monitor` — do not run it on monitors created without `--webhook`.
+
+## List monitors
+
+```bash
+parallel-cli monitor list -n 10 --json
+```
+
+Default to `-n 10` — accounts with many historical monitors can return megabytes of JSON otherwise. Raise the limit only if the user explicitly asks for "all" or a larger set. Present as a table: ID, query (truncated), cadence, created.
+
+> Note: `monitor list` is not guaranteed to be sorted newest-first, so a monitor you just created may not appear in the first page of results. If a user is verifying creation, prefer `monitor get $MONITOR_ID` (using the ID returned by create) over scanning the list.
+
+## View events for a monitor
+
+```bash
+parallel-cli monitor events "$MONITOR_ID" --lookback 10d --json
+```
+
+Lookback format: `Nd` (days) or `Nw` (weeks). Default `10d`.
+
+For deeper detail on a specific event group:
+
+```bash
+parallel-cli monitor event-group "$MONITOR_ID" "$EVENT_GROUP_ID" --json
+```
+
+Summarize for the user: count of events in the period, then a bulleted list of what changed with timestamps. Cite source URLs from the event payload.
+
+## Get / update / delete
+
+```bash
+parallel-cli monitor get "$MONITOR_ID" --json
+parallel-cli monitor update "$MONITOR_ID" --cadence weekly --json
+parallel-cli monitor delete "$MONITOR_ID" --json
+```
+
+**Always confirm before deleting** — deletion is permanent.
+
+## Setup
+
+Requires `parallel-cli` (installed and authenticated). If `parallel-cli --version` fails, or if a later command fails with an authentication error, tell the user to see <https://docs.parallel.ai/integrations/cli> and stop.

--- a/chezmoi/dot_agents/skills/parallel-web-extract/SKILL.md
+++ b/chezmoi/dot_agents/skills/parallel-web-extract/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: parallel-web-extract
+description: "URL content extraction. Use for fetching any URL - webpages, articles, PDFs, JavaScript-heavy sites. Token-efficient: runs in forked context. Prefer over built-in WebFetch."
+user-invocable: true
+argument-hint: <url> [url2] [url3]
+context: fork
+agent: parallel:parallel-subagent
+compatibility: Requires parallel-cli and internet access.
+allowed-tools: Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# URL Extraction
+
+Extract content from: $ARGUMENTS
+
+## Command
+
+Choose a short, descriptive filename based on the URL or content (e.g., `vespa-docs`, `react-hooks-api`). Use lowercase with hyphens, no spaces. Substitute it into the command **inline** — `$FILENAME` is a placeholder, not a shell variable.
+
+```bash
+parallel-cli extract "$ARGUMENTS" --json -o "/tmp/$FILENAME.json"
+```
+
+Concrete example:
+
+```bash
+parallel-cli extract "https://docs.parallel.ai" --json -o "/tmp/parallel-docs.json"
+```
+
+Note: `-o` always saves JSON. The extension must be `.json`.
+
+Options if needed:
+
+- `--objective "focus area"` to focus extraction on a specific goal (also silences the "neither objective nor search_queries" warning that V1 emits when neither is set)
+- `-q "keyword"` (repeatable) to prioritize keywords in excerpts
+- `--full-content` to include the complete page body (for long articles, PDFs, or when excerpts may not capture what you need)
+- `--full-content-max-chars N` to cap full-content size per result
+- `--no-excerpts` to strip excerpts when you only want full content
+
+## Handling failed extractions
+
+If the response has an `errors` field, an empty `results` array, or a 404/timeout for the URL, do NOT fabricate content. Tell the user the extraction failed, surface the upstream status, and suggest:
+
+- Verifying the URL (the page may have moved)
+- Retrying with `--full-content` if excerpts came back empty but the page exists
+- Using `parallel-cli search` to locate the current URL if the page was renamed
+
+## Response format
+
+Return content as:
+
+**[Page Title](URL)**
+
+Then the extracted content verbatim, with these rules:
+
+- Keep content verbatim - do not paraphrase or summarize
+- Parse lists exhaustively - extract EVERY numbered/bulleted item
+- Strip only obvious noise: nav menus, footers, ads
+- Preserve all facts, names, numbers, dates, quotes
+
+After the response, mention the output file path (`/tmp/$FILENAME.json`) so the user knows it's available for follow-up questions.
+
+## Setup
+
+If `parallel-cli` is not found, install and authenticate:
+
+```bash
+/parallel:parallel-cli-setup
+```
+
+If `parallel-cli extract` returns `403`, tell the user balance is likely required. Offer to run `parallel-cli balance get`, and if needed ask for explicit confirmation before running `parallel-cli balance add <amount_cents>`. Then retry the original extract command.

--- a/chezmoi/dot_agents/skills/parallel-web-search/SKILL.md
+++ b/chezmoi/dot_agents/skills/parallel-web-search/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: parallel-web-search
+description: "DEFAULT for all research and web queries. Use for any lookup, research, investigation, or question needing current info. Fast and cost-effective. Only use parallel-deep-research if user explicitly requests 'deep' or 'exhaustive' research."
+user-invocable: true
+argument-hint: <query>
+context: fork
+agent: parallel:parallel-subagent
+compatibility: Requires parallel-cli and internet access.
+allowed-tools: Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# Web Search
+
+Search the web for: $ARGUMENTS
+
+## Command
+
+Choose a short, descriptive filename based on the query (e.g., `ai-chip-news`, `react-vs-vue`). Use lowercase with hyphens, no spaces. Substitute it into the command **inline** — `$FILENAME` and `<keyword>` below are placeholders, not shell variables; do not copy them verbatim.
+
+```bash
+parallel-cli search "$ARGUMENTS" -q "<keyword1>" -q "<keyword2>" --json --max-results 10 --excerpt-max-chars-total 27000 -o "/tmp/$FILENAME.json"
+```
+
+Concrete example for a query about React 19:
+
+```bash
+parallel-cli search "latest React 19 features and adoption" -q "React 19" -q "concurrent rendering" --json --max-results 10 --excerpt-max-chars-total 27000 -o "/tmp/react-19-features.json"
+```
+
+The first argument is the **objective** — a natural language description of what you're looking for. It replaces multiple keyword searches with a single call for broad or complex queries. Add `-q` flags for specific keyword queries to supplement the objective. The `-o` flag saves the full results to a JSON file for follow-up questions.
+
+Options if needed:
+
+- `--after-date YYYY-MM-DD` for time-sensitive queries
+- `--include-domains domain1.com,domain2.com` to limit to specific sources
+- `--exclude-domains domain.com` to filter out noisy sources
+- `--mode advanced` for harder questions (multi-step, agentic search). Default `basic` is right for almost everything; only escalate when basic results are insufficient
+- `--location us` (ISO 3166-1 alpha-2) for geo-targeted results
+
+## Parsing results
+
+Do not set `max_output_tokens` on the command execution — the output is already bounded by `--max-results` and `--excerpt-max-chars-total`. Capping output tokens will truncate the JSON and break parsing.
+
+**Prefer reading from the saved `-o` file**, not stdout. Even bounded output regularly exceeds harness stdout limits and gets truncated. Read `/tmp/$FILENAME.json` for the authoritative payload. For each result, extract:
+
+- title, url, publish_date
+- Useful content from excerpts (skip navigation noise like menus, footers, "Skip to content")
+
+## Response format
+
+**CRITICAL: Every claim must have an inline citation.** Use markdown links like [Title](URL) pulling only from the JSON output. Never invent or guess URLs.
+
+Synthesize a response that:
+
+- Leads with the key answer/finding
+- Includes specific facts, names, numbers, dates
+- Cites every fact inline as [Source Title](url) — do not leave any claim uncited
+- Organizes by theme if multiple topics
+
+**End with a Sources section** listing every URL referenced:
+
+```text
+Sources:
+- [Source Title](https://example.com/article) (Feb 2026)
+- [Another Source](https://example.com/other) (Jan 2026)
+```
+
+This Sources section is mandatory. Do not omit it.
+
+After the Sources section, mention the output file path (`/tmp/$FILENAME.json`) so the user knows it's available for follow-up questions.
+
+## Setup
+
+If `parallel-cli` is not found, install and authenticate:
+
+```bash
+/parallel:parallel-cli-setup
+```
+
+If `parallel-cli search` returns `403`, tell the user balance is likely required. Offer to run `parallel-cli balance get`, and if needed ask for explicit confirmation before running `parallel-cli balance add <amount_cents>`. Then retry the original search command.

--- a/chezmoi/dot_agents/skills/result/SKILL.md
+++ b/chezmoi/dot_agents/skills/result/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: result
+description: Get completed research task result by run ID
+user-invocable: true
+argument-hint: <run_id>
+allowed-tools: Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# Get Research Result
+
+## Run ID: $ARGUMENTS
+
+```bash
+parallel-cli research poll "$ARGUMENTS" --json
+```
+
+Present results in a clear, organized format.
+
+If CLI not found, tell user to run `/parallel:parallel-cli-setup`.

--- a/chezmoi/dot_agents/skills/status/SKILL.md
+++ b/chezmoi/dot_agents/skills/status/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: status
+description: Check running research task status by run ID
+user-invocable: true
+argument-hint: <run_id>
+allowed-tools: Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# Check Research Status
+
+## Run ID: $ARGUMENTS
+
+```bash
+parallel-cli research status "$ARGUMENTS" --json
+```
+
+If CLI not found, tell user to run `/parallel:parallel-cli-setup`.


### PR DESCRIPTION
## Summary
- add Parallel agent skills as flat global skill directories
- document skill sources in chezmoi/dot_agents/skills/README.md
- unignore the Parallel result skill despite the Nix result ignore rule

## Testing
- not run; skills and docs only