### PR TITLE
fix(cleanup): keep Nix cleanup conservative

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,11 @@ nix run home-manager -- switch --flake ~/dotfiles/home-manager
 # Enable repo-managed Determinate Nix custom warnings
 ~/dotfiles/scripts/configure-nix-custom.sh
 
-# Clean old Nix generations, collect garbage, and compact Nix caches
+# Clean older Nix generations, keeping the 5 most recent rollback points
 ~/dotfiles/scripts/cleanup.sh
+
+# Override the retained generation count for a one-off run
+NIX_CLEANUP_KEEP_GENERATIONS=3 ~/dotfiles/scripts/cleanup.sh
 ```
 
 #### Manage Personal Configs (via Chezmoi)

--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -81,6 +81,7 @@ bun = "1.3.11"
 "aqua:dprint/dprint" = "0.54.0"  # Fast pluggable code formatter
 "aqua:j178/prek" = "0.4.3"      # pre-commit re-engineered in Rust
 "aqua:chmln/sd" = "1.1.0"       # sed replacement (simpler syntax)
+"aqua:koalaman/shellcheck" = "0.11.0"  # Shell script static analyzer
 "aqua:mikefarah/yq" = "4.52.5"  # YAML processor
 "aqua:terrastruct/d2" = "0.7.1"  # Diagram language
 "aqua:typst/typst" = "0.14.2"   # Typesetting system

--- a/chezmoi/dot_config/mise/mise.lock
+++ b/chezmoi/dot_config/mise/mise.lock
@@ -170,6 +170,10 @@ checksum = "sha256:23cb60a1354eed6bcc8d9b9735e8c7b388cd1fdcb75726b93bc299ef22dd9
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-windows-amd64.exe"
 provenance = "github-attestations"
 
+[[tools."aqua:koalaman/shellcheck"]]
+version = "0.11.0"
+backend = "aqua:koalaman/shellcheck"
+
 [[tools."aqua:mikefarah/yq"]]
 version = "4.52.5"
 backend = "aqua:mikefarah/yq"
@@ -610,6 +614,10 @@ url = "https://nodejs.org/dist/v24.14.1/node-v24.14.1-darwin-x64.tar.gz"
 [tools.node."platforms.windows-x64"]
 checksum = "sha256:6e50ce5498c0cebc20fd39ab3ff5df836ed2f8a31aa093cecad8497cff126d70"
 url = "https://nodejs.org/dist/v24.14.1/node-v24.14.1-win-x64.zip"
+
+[[tools."npm:@nozomioai/nia"]]
+version = "0.5.2"
+backend = "npm:@nozomioai/nia"
 
 [[tools."npm:hunkdiff"]]
 version = "0.13.2"

--- a/chezmoi/dot_config/zsh/custom.zsh
+++ b/chezmoi/dot_config/zsh/custom.zsh
@@ -30,7 +30,7 @@ eval "$(mise activate zsh)"
 
 # Fix PATH for nix-darwin (macOS path_helper overrides /etc/zshenv)
 # Add Nix paths AFTER mise so mise tools take precedence
-[[ ":$PATH:" != *":/etc/profiles/per-user/$USER/bin:"* ]] && export PATH="/etc/profiles/per-user/$USER/bin:$PATH"
+[[ ":$PATH:" != *":/etc/profiles/per-user/$USER/bin:"* ]] && export PATH="$PATH:/etc/profiles/per-user/$USER/bin"
 
 # Only append to PATH if these directories aren't already there
 [[ ":$PATH:" != *":$HOME/.opencode/bin:"* ]] && export PATH="$PATH:$HOME/.opencode/bin"

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,38 +1,47 @@
 #!/usr/bin/env bash
 # Nix store/cache cleanup and maintenance
 #
-# Run periodically to free disk space by removing old generations
-# garbage collecting unreferenced store paths, and compacting Nix caches.
+# Run periodically to free disk space by removing older generations while
+# preserving recent rollback points, garbage collecting unreferenced store paths,
+# and compacting Nix caches.
 
 set -euo pipefail
 
 echo "=== Nix Store Cleanup ==="
+keep_generations="${NIX_CLEANUP_KEEP_GENERATIONS:-5}"
+
+if ! [[ "$keep_generations" =~ ^[1-9][0-9]*$ ]]; then
+    echo "NIX_CLEANUP_KEEP_GENERATIONS must be a positive integer" >&2
+    exit 1
+fi
+
+echo "Retention: keeping the most recent $keep_generations generations"
 echo "Before:"
 du -sh /nix/store
 du -sh "$HOME/.cache/nix" 2>/dev/null || true
 
 echo ""
-echo "Deleting old generations..."
+echo "Deleting generations outside the retention window..."
 
-# Delete old darwin-system generations (keeps only current)
+# Delete older darwin-system generations while keeping recent rollback points
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "  - darwin-system generations"
-    sudo nix-env --delete-generations old --profile /nix/var/nix/profiles/system
+    sudo nix-env --delete-generations +"$keep_generations" --profile /nix/var/nix/profiles/system
 fi
 
-# Delete old home-manager generations
+# Delete older home-manager generations while keeping recent rollback points
 if [[ -d ~/.local/state/nix/profiles ]]; then
     echo "  - home-manager generations"
-    nix-env --delete-generations old --profile ~/.local/state/nix/profiles/home-manager 2>/dev/null || true
+    nix-env --delete-generations +"$keep_generations" --profile ~/.local/state/nix/profiles/home-manager 2>/dev/null || true
 fi
 
-# Delete old user profile generations
+# Delete older user profile generations while keeping recent rollback points
 echo "  - user profile generations"
-nix-env --delete-generations old
+nix-env --delete-generations +"$keep_generations"
 
 echo ""
 echo "Running garbage collection..."
-nix-collect-garbage -d
+nix-collect-garbage
 
 echo ""
 echo "Cleaning Nix tarball caches..."


### PR DESCRIPTION
- Keep recent Nix generations during cleanup instead of pruning all rollback points.
- Add `NIX_CLEANUP_KEEP_GENERATIONS` and document the one-off override.
- Keep Mise-managed tools ahead of Nix in `PATH`, add `shellcheck`, and refresh the Mise lockfile.
- Verified with `bash -n`, `shellcheck`, `mise install --locked`, and a GitHub connector write test.