### PR TITLE
chore(crush): harden Executor MCP bridge

### DIFF
--- a/chezmoi/dot_config/crush/crush.json
+++ b/chezmoi/dot_config/crush/crush.json
@@ -34,8 +34,12 @@
   },
   "mcp": {
     "executor": {
-      "type": "http",
-      "url": "https://executor.sh/mcp",
+      "type": "stdio",
+      "command": "mise",
+      "args": ["exec", "--", "sfw", "npx", "-y", "mcp-remote@0.1.38", "https://executor.sh/mcp", "--transport", "http-only"],
+      "env": {
+        "SFW_SKIP_UPDATE_CHECK": "1"
+      },
       "timeout": 120
     }
   },

--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -38,6 +38,7 @@ bun = "1.3.11"
 "npm:markit-ai" = "0.5.3"
 "npm:hunkdiff" = "0.13.2"       # review-first terminal diff viewer
 "npm:@nozomioai/nia" = "0.5.2"  # Nia CLI only
+"npm:sfw" = "2.0.6"             # Socket Firewall wrapper for package manager network filtering
 
 # ============================================================================
 # Python CLI Tools from PyPI
@@ -72,7 +73,7 @@ bun = "1.3.11"
 # ============================================================================
 # Tools from Aqua (GitHub releases with verification)
 # ============================================================================
-"aqua:charmbracelet/crush" = "0.73.0"
+"aqua:charmbracelet/crush" = "0.76.0"
 "aqua:openai/codex" = "0.134.0"
 "aqua:sharkdp/bat" = "0.26.1"  # cat replacement with syntax highlighting
 "aqua:dandavison/delta" = "0.19.2"  # git diff viewer

--- a/chezmoi/dot_config/mise/mise.lock
+++ b/chezmoi/dot_config/mise/mise.lock
@@ -31,12 +31,12 @@ url = "https://awscli.amazonaws.com/AWSCLIV2-2.34.18.pkg"
 url = "https://awscli.amazonaws.com/AWSCLIV2-2.34.18.pkg"
 
 [[tools."aqua:charmbracelet/crush"]]
-version = "0.73.0"
+version = "0.76.0"
 backend = "aqua:charmbracelet/crush"
 
 [tools."aqua:charmbracelet/crush"."platforms.macos-arm64"]
-checksum = "sha256:e8a0aa570c5bbe8f31b444079b558dcba63d2d90fc0d4201f1248b2a84169017"
-url = "https://github.com/charmbracelet/crush/releases/download/v0.73.0/crush_0.73.0_Darwin_arm64.tar.gz"
+checksum = "sha256:6dec0cb0209219d95e4fbc64b62bb9acaf68ae6f1d44b342f69e2ec7098b56e1"
+url = "https://github.com/charmbracelet/crush/releases/download/v0.76.0/crush_0.76.0_Darwin_arm64.tar.gz"
 provenance = "cosign"
 
 [[tools."aqua:chmln/sd"]]
@@ -626,6 +626,10 @@ backend = "npm:hunkdiff"
 [[tools."npm:markit-ai"]]
 version = "0.5.3"
 backend = "npm:markit-ai"
+
+[[tools."npm:sfw"]]
+version = "2.0.6"
+backend = "npm:sfw"
 
 [[tools."npm:wrangler"]]
 version = "4.94.0"


### PR DESCRIPTION
## Summary

- Upgrade [Crush][crush] to 0.76.0.
- Route the [Executor][executor] Cloud MCP through pinned `mcp-remote@0.1.38` under [Socket Firewall][sfw].
- Pin `sfw@2.0.6` in Mise so the wrapper is managed with the rest of the toolchain.

## Socket Firewall

- [Socket Firewall Free][sfw-docs] is a lightweight package-manager network proxy that blocks malicious dependencies before they reach a developer machine or build system.
- It is designed to prefix package-manager commands, and the free edition officially covers JavaScript/TypeScript package managers plus Python and Rust flows like `npm`, `yarn`, `pnpm`, `pip`, `uv`, and `cargo`.
- Here it wraps `npx -y mcp-remote@0.1.38`, so the runtime fetch path for the Crush-to-Executor bridge gets malware filtering while keeping the MCP upstream as [Executor][executor] Cloud.

## Notes

- `SFW_SKIP_UPDATE_CHECK=1` is set for this MCP bridge because the npm `sfw` wrapper can download/cache the platform binary and check for updates in the background; skipping update checks keeps MCP startup from introducing surprise background refreshes once the verified binary is cached.
- The Crush MCP entry uses `mise exec -- sfw npx ...` so the pinned Mise tool is resolved reliably even when the shell PATH is stale.
- Potential follow-ups: wrap other transient package-manager executions such as `npx skills`, `npx firecrawl`, `npx add-mcp`, and `pnpm dlx` aliases where they execute third-party packages at runtime.

## Verification

- `jq empty chezmoi/dot_config/crush/crush.json`
- `mise exec -- sfw --help`
- `crush --debug --cwd /Users/kevinchen/dotfiles run "Say ok."`

[crush]: https://charm.land/crush
[executor]: https://executor.sh/
[sfw]: https://github.com/SocketDev/sfw-free
[sfw-docs]: https://docs.socket.dev/docs/socket-firewall-free
