### PR TITLE
chore(git): prepare local maintenance config

### DIFF
--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -106,7 +106,7 @@ bun = "1.3.11"
 #   - mise: installs the tools defined here
 #
 # System-level packages (not available or not suitable for Mise):
-#   - git: macOS system package
+#   - git: Home Manager package
 #   - git-town: advanced git workflows
 #   - _1password-cli: 1Password CLI
 #   - cloudflared: Cloudflare tunnel daemon (wrangler is Workers CLI, different tool)

--- a/chezmoi/dot_gitconfig
+++ b/chezmoi/dot_gitconfig
@@ -9,6 +9,8 @@
 	pager = delta
 [includeIf "gitdir:~/dev/github.com/kevinmichaelchen/"]
     path = ~/.config/git/kevinmichaelchen
+[include]
+	path = ~/.config/git/local
 [pager]
 	branch = false
 [git-town]


### PR DESCRIPTION
## Summary

- Adds a local Git config include for machine-specific settings.
- Keeps Git maintenance repo lists out of tracked dotfiles.
- Fixes the Mise note so it says Git is managed by Home Manager.

## Manual steps

I did not run these commands.

```sh
chezmoi apply
mkdir -p ~/.config/git
touch ~/.config/git/local
git maintenance start --scheduler=launchctl
git maintenance register --config-file ~/.config/git/local
```

To update Git through Nix, update the flake locks and rebuild:

```sh
cd ~/dotfiles/home-manager
nix flake update nixpkgs
cd ~/dotfiles/nix-darwin
nix flake update nixpkgs
darwin-rebuild switch --flake ~/dotfiles/nix-darwin#default
```