### PR TITLE
feat: Add hegelian dialectic skill

### DIFF
--- a/chezmoi/dot_agents/skills/README.md
+++ b/chezmoi/dot_agents/skills/README.md
@@ -55,4 +55,6 @@ given explicit lock entries:
 - `firecrawl-monitor`
 - `garden-tender`
 - `git-commit-convention`
+- `hegelian-dialectic-skill` from
+  [`KyleAMathews/hegelian-dialectic-skill`](https://github.com/KyleAMathews/hegelian-dialectic-skill)
 - `replicate`

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/.gitignore
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/.gitignore
@@ -1,0 +1,2 @@
+.opentrace/
+.opentrace-index.log

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/README.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/README.md
@@ -1,0 +1,179 @@
+# The Electric Monks — Dialectic Skill
+
+*Named after Douglas Adams' machines built to believe things for you*
+
+**An agent skill that helps you think better by automating the brutally expensive parts of deep reasoning.**
+
+Two AI subagents — the Electric Monks — *believe* fully committed positions on your behalf. A third, the orchestrator, decomposes both arguments into atomic parts, finds cross-domain connections, and synthesizes. The result is a **semi-lattice** — a structure no single linear argument could produce.
+
+You operate from a belief-free position above the Monks, analyzing the *structure* of the contradiction rather than being inside either side. This isn't artificial intelligence — it's an **artificial belief system** that frees you to think.
+
+**What the output feels like:** Left alone, LLMs produce shallow takes. The dialectic breaks that pattern. As you read through the Monks' committed arguments, connections come to mind — things neither side considered, corrections to their framing, ideas you hadn't articulated yet. You feed these back in. The skill tunes to your thinking more and more with each round, but it also rigorously exposes the contradictions in that thinking — so you get an increasingly full and precise map of your own ideas. Then the skill breaks it apart and reforms it as something richer and more interesting than what you started with. Each synthesis becomes the next round's thesis, and by Round 2–3 the dialectic is operating in territory no single prompt could reach.
+
+**Why this works** — thinking well about hard problems has at least three bottlenecks, and they compound:
+
+1. **Belief.** Once you hold a position, you can't simultaneously entertain its negation at full strength. You hedge, steelman weakly, unconsciously bias the comparison.
+2. **Research breadth.** Surveying a domain's thinkers, history, and adjacent fields takes enormous time. Most people stop too early.
+3. **Structural comparison.** Even with two positions side by side, decomposing them into atomic parts and finding cross-domain connections is cognitively brutal. Most analysis stalls here.
+
+LLMs can do all three at a scale and speed humans can't. This skill orchestrates them to do exactly that.
+
+## When to Use
+
+- **You've locked onto a vision and can't genuinely entertain alternatives.** You have a strong thesis — maybe an architecture, a strategy, a life direction — and you want to stress-test it, but you keep steelmanning the other side weakly.
+- **You're trying to do everything because cutting anything feels like betrayal.** Competing needs all feel equally urgent. You can't triage because every priority has someone counting on it.
+- **You can argue every side but can't commit to any of them.** You find the question intellectually interesting but "what do *you* actually think?" produces discomfort. You've explored this before without resolution.
+- **You've optimized a system and suspect you might be optimizing the wrong thing.** Your approach works — you have data to prove it — but the landscape may have shifted and you can't see past your own competence.
+- **Your own values contradict each other.** You believe multiple things passionately, each feels individually right, but collectively they're impossible. The tension is internal, not external.
+- **"This is how it's done" has become invisible as an assumption.** You have deep knowledge of how things work, but you suspect it's blinding you to radically different approaches.
+
+Works across domains — technical architecture, product strategy, philosophy, personal decisions.
+
+## Usage
+
+The skill works with any coding agent that supports subagent spawning and web search — Claude Code, Cursor, Windsurf, etc.
+
+**This is a heavy process by design.** Expect 10–15 minutes per round minimum, and plan for at least 3 rounds. This skill needs the best available model — every phase benefits from maximum reasoning capability.
+
+### Setup
+
+Create a directory to collect your dialectics (e.g., `dialectics/`). Each dialectic gets its own subdirectory — the skill generates several files per round, all prefixed with the round number for easy navigation.
+
+```
+dialectics/
+├── tanstack-vs-nextjs/
+│   ├── round_1_context_briefing.md
+│   ├── round_1_monk_a.md
+│   ├── round_1_monk_b.md
+│   ├── round_1_determinate_negation.md
+│   ├── round_1_sublation.md
+│   ├── round_1_validation.md
+│   ├── round_2_monk_a.md
+│   ├── round_2_monk_b.md
+│   ├── round_2_determinate_negation.md
+│   ├── round_2_sublation.md
+│   └── dialectic_queue.md
+├── agent-governance/
+│   └── ...
+└── career-decision/
+    └── ...
+```
+
+### Running a Dialectic
+
+1. Create a subdirectory for your topic:
+   ```bash
+   mkdir -p ~/dialectics/my-topic && cd ~/dialectics/my-topic
+   ```
+
+2. Load the skill and give it your question:
+   ```bash
+   mkdir .claude/skills/hegelian-dialectic-skill
+   wget https://raw.githubusercontent.com/KyleAMathews/hegelian-dialectic-skill/refs/heads/main/SKILL.md
+   mv SKILL.md .claude/skills/hegelian-dialectic-skill
+   ```
+
+2. Start your coding agent in that directory:
+   ```bash
+   claude
+
+   /dialectic I want to explore: [your topic or tension here]
+   ```
+
+   The skill will walk you through the elenctic interview, spawn the Monks, and produce the full dialectical trace — all saved as files in the current directory.
+
+   You can also just run /dialectic to get an introductory help message that walks you through the process.
+
+### Tips
+
+- **You are the co-pilot.** Interrupt, correct, redirect at any point. The Monks will get things wrong. Your corrections are the highest-leverage input in the entire process.
+- **The first round is calibration.** Don't judge the skill by Round 1. The real insights come in Rounds 2–3, once the process has dug past the obvious framing.
+- **Say yes to recursion.** When the skill proposes recursive directions after a synthesis, pick one. Each round ratchets up the quality.
+- **The dialectic queue persists.** The `dialectic_queue.md` file tracks explored and unexplored contradictions. You can come back to it in a future session and pick up where you left off.
+
+## How It Works
+
+The process has seven phases.
+
+### Phase 1: Elenctic Interview + Research — surface the real contradiction
+
+The orchestrator interviews you Socratically — surfacing hidden assumptions, finding the deepest version of the contradiction, and identifying your belief burden. Then it researches the domain to ground both sides in specifics. The interview surfaces what you're *actually* wrestling with; the research ensures the downstream arguments are grounded in specifics, not generics.
+
+### Phase 2: Generate Electric Monk Prompts — calibrate the belief assignments
+
+The orchestrator crafts two prompts — one per Monk — calibrated to your specific belief burden. Each prompt includes framing corrections that prevent the Monk from falling into the obvious, boring version of the argument, plus targeted research directives for position-specific evidence.
+
+### Phase 3: Spawn the Electric Monks — two fully committed position essays
+
+Two separate AI agents — each in a fresh, isolated context — write fully committed position essays. They don't hedge. They don't try to be balanced. Each one *inhabits* its position and makes the absolute strongest case. Spawning them in separate sessions with no shared context produces structural decorrelation — genuinely different reasoning paths, not the same analysis with different conclusions bolted on.
+
+### Phase 4: Determinate Negation — find where each argument undermines itself
+
+The orchestrator analyzes both essays to find: where each position's own logic undermines itself (self-sublation), what both sides implicitly agree on without realizing it (shared assumptions), and the *specific* way each position fails — not "it's wrong" but "it fails in THIS way, which points toward THIS thing that's missing."
+
+Then comes Boyd's destructive deduction: shatter both arguments into atomic parts, break the correspondence between each position and its constituents, and scatter them into what Boyd calls a "sea of anarchy." Then the creative induction: find common qualities, attributes, or operations among the scattered parts to build cross-domain connections that were invisible when the parts were trapped inside their original positions. Lateral creativity interventions (compressed conflicts, multi-domain donor recruitment — random Wikipedia donors plus functional donors targeted at each position's missing capacity — and metaphor generation) inject genuinely external material before the decomposition, so the donors get shattered and recombined alongside the monks' material at equal depth.
+
+### Phase 5: Palette of Candidates — structurally distinct ways the dialectic can land
+
+Collapsing everything to a single synthesis biases toward smoothing away the very angles the dialectic worked to produce. So instead the orchestrator drafts a **palette of structurally-distinct candidates**. **S (Synthesis)** is always drafted — Hegel's Aufhebung: simultaneously *cancel* both positions as complete truths, *preserve* the genuine insight in each, and *elevate* to a new concept that transforms the question. Alongside it, conditional candidates fire only when the misfit register earned them: **J** (sustained juxtaposition — hold the contradiction open), **G** (ground condition — the resolution lives at a different level), **F** (framing dissolution — the binary is a fossil), and **U** (undecidable-centered — the dispute *is* a word both sides load oppositely). Each candidate is written by a decorrelated subagent with no sight of its siblings, and the orchestrator presents them side-by-side without ranking or recommending — you are in the belief-free judging seat.
+
+S in particular is not compromise. It's not "use A for some cases and B for others." It's a reconceptualization — something neither Monk could have conceived from within their frame, but which, once stated, makes the original contradiction *predictable.* S is an abductive hypothesis: what would make it *unsurprising* that both Monk positions exist with genuine evidence? After drafting, a reversibility check (from Boyd) traces each claim back to specific atomic parts from the decomposition; untraceable claims trigger a repair loop — keep what coheres, add new material, re-derive — before any claim is kept as net-new or cut.
+
+### Phase 6: Validation — did the Monks feel elevated or defeated?
+
+Both Monks evaluate the candidate(s) you sent through: were they *elevated* (their core insight preserved within something larger) or *defeated* (their position just dismissed)? Then a hostile auditor — a fresh agent with no position — attacks the candidate for hidden assumptions, compromise disguised as transcendence, structural flaws, and runs its own reversibility check (can each claim trace to material in the essays, or is the synthesis just one monk's structure wearing the other's vocabulary?).
+
+### Phase 7: Recursion — where the real value lives
+
+Each synthesis generates new contradictions. The orchestrator proposes 2–4 directions; you choose which to pursue. The process repeats — and each round gets sharper, pulling in new cross-domain material that the previous round made relevant.
+
+The first round is calibration — the least insightful output. By Round 2–3, the dialectic has dug past the obvious framing into territory that neither you nor the Monks could have reached from the starting question. In test runs, a React/Vue dialectic evolved from "corporate lab vs. auteur" into a "co-evolutionary arms race" framework. An institutional identity dialectic went through seven cycles, pulling in Gödel's incompleteness theorem, Coasean transaction costs, and jurisprudential concepts that had nothing to do with the original question — but were essential by the time the dialectic reached them.
+
+## The Theory
+
+The skill rests on three theoretical frameworks — one per bottleneck — plus Alexander's semi-lattice theory, which explains why the output is structurally richer than any single line of reasoning.
+
+### Rao: The Belief Bottleneck
+
+From Venkatesh Rao's "Electric Monks" framework (after Douglas Adams). Rao argues there are three ways to speed up your cognitive transients: (a) maintain a richer library of mental models, (b) switch between them faster, (c) believe fewer things. The first two hit hard limits — more models means higher search costs, faster switching runs into biology. Only the third has no ceiling: if machines carry the belief load, you can become a pure context-switching specialist.
+
+Boyd's analogy: in the Korean War, F-86 Sabres achieved a 10:1 kill ratio against MIG-15s despite similar flight capabilities. The difference was hydraulic controls — the pilot could reorient faster because the plane did the mechanical work. But the transients weren't just faster, they were *better* — by devoting less attention to struggling with controls, the pilot chose better maneuvers. The Monks work the same way: by carrying the belief work, they don't just save you time, they free up cognitive capacity that goes into higher-quality structural analysis.
+
+Rao wrote this framework before LLMs. Belief inertia is real, but it's not the only bottleneck — and arguably not the most expensive one.
+
+### Eisenstein + Boyd: The Research and Decomposition Bottlenecks
+
+Elizabeth Eisenstein argued that the printing press's most transformative effect wasn't making books cheap — it was **typographic fixity.** For the first time, scholars could lay texts side by side and detect contradictions. Before print, you read one manuscript, traveled to another library, read another, and tried to hold the comparison in your head.
+
+LLMs represent the next step: not just fixity and side-by-side comparison, but *automated structural comparison.* Both remaining bottlenecks — research breadth and structural decomposition — are cognitively brutal. Most people abandon the first too early and never attempt the second.
+
+This is where Boyd's "Destruction and Creation" (1976) enters. Boyd calls the two operations *destructive deduction* (shatter existing conceptual domains, break the correspondence between each concept and its parts, scatter them into a "sea of anarchy") and *creative induction* (find common qualities, attributes, or operations among the scattered parts to synthesize something genuinely new). The critical constraint: the result must NOT reassemble the parts in the same arrangement as any original domain — that's rearrangement, not creation.
+
+Boyd proves this isn't optional. Three pillars: Gödel shows you can't verify a system's consistency from inside it. Heisenberg shows that inward refinement creates observer-observed feedback loops. The Second Law shows that any closed system's entropy necessarily increases. Together: "any inward-oriented and continued effort to improve the match-up of concept with observed reality will only increase the degree of mismatch." You *must* go outside.
+
+This decomposition work — stripping claims from their source, searching for cross-domain connections — is the structural comparison Eisenstein identified as transformative when print first enabled it. LLMs can do it at a scale and speed that makes multi-round recursive dialectics practical in a single session. And Boyd's three pillars explain why each recursive round needs new external material: the system must open itself or face increasing entropy.
+
+### Hegel: Determinate Negation and Aufhebung
+
+*Determinate negation* doesn't say "this is wrong." It says "this is wrong in a *specific way* that points toward what's missing." The failure mode is a signpost. Sublation (Aufhebung) simultaneously cancels, preserves, and elevates — it produces a reframing so complete that the original terms of the debate stop making sense. Kant didn't resolve the rationalism/empiricism debate by splitting the difference. He showed that experience provides content while reason provides structure — and once you see that, the original question ("does knowledge come from reason or experience?") dissolves. It's not that you pick a side. It's that you can't even think in the old terms anymore. That irreversibility is what distinguishes genuine synthesis from compromise.
+
+### Alexander: Semi-Lattice Generation
+
+Christopher Alexander showed that natural cities have **semi-lattice** structure — overlapping, cross-connected sets — while designed cities impose **tree** structure where every element belongs to exactly one branch. Trees are easier to think about but destroy the cross-connections that make systems alive.
+
+Language is tree-structured. Every argument a Monk produces is a tree — a coherent linear path from premises to conclusions. But the Boydian decomposition phase strips both arguments of their tree structure, extracts atomic parts, and finds cross-connections between elements that came from different trees. These cross-domain connections *are* the semi-lattice edges. The synthesis is the semi-lattice that emerges from the overlap.
+
+**The skill is a semi-lattice compiler.** The answer to "language can't represent semi-lattices" is not "make the LLM output a semi-lattice directly." It's: produce multiple committed trees from different positions, then extract the cross-connections. The semi-lattice is *constructed*, not generated. Every successful semi-lattice system works this way — Gene Ontology (multiple studies cross-referenced into a DAG), McChrystal's Team of Teams (tree-structured teams with liaison officers creating cross-connections), Ostrom's polycentric governance (overlapping jurisdictions, not one hierarchy).
+
+### Additional Theoretical Foundations
+
+- **Socratic Elenchus** — the interview phase surfaces hidden assumptions through questioning, reaching productive perplexity (aporia)
+- **Peirce's Abduction** — the synthesis is an abductive hypothesis: what would make the contradiction *unsurprising*?
+- **Galinsky's Perspective-Taking Research** — inhabiting a position produces richer arguments than advocating for one, which is why the Monks *are* their positions rather than arguing for them
+- **Multi-Agent Debate Literature** (Du et al.) — multiple agents debating improves reasoning; heterogeneous agents outperform homogeneous ones; agents are too agreeable by default (the anti-hedging instructions counter this)
+- **Pollock's Defeasible Reasoning** — the hostile auditor distinguishes undercutting defeaters (broken inferential links) from rebutting defeaters (counter-evidence), prioritizing structural critique
+- **Aquinas** — "The slenderest knowledge of the highest things is more desirable than the most certain knowledge of lesser things." The dialectic produces provisional knowledge of deep structure, not confident answers to surface questions
+
+## License
+
+MIT

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/SKILL.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/SKILL.md
@@ -1,0 +1,504 @@
+---
+name: dialectic
+description: An Electric Monk engine — two subagents believe fully committed positions on the user's behalf while the orchestrator performs structural contradiction analysis and synthesis. By outsourcing belief work to agents, the user operates from a belief-free position where they can analyze the structure of the contradiction rather than being inside either side. Use when the user wants to stress-test an idea, resolve a genuine tension, build a deeper mental model, or make a high-stakes decision where the tradeoffs are unclear. Works across any domain — technical architecture, product strategy, philosophy, personal decisions, risk analysis, policy, creative direction.
+---
+
+# The Electric Monks — Dialectic Skill
+
+An **artificial belief system** for building deeper understanding through productive contradiction.
+
+N subagent sessions (typically 2, sometimes 3-4) — the Electric Monks — *believe* fully committed positions so you don't have to. The orchestrator performs structural analysis of their contradiction and generates a **palette of structurally-distinct candidates** for where the contradiction lands — synthesis (Hegel), juxtaposition (Adorno), ground-condition (Schumacher), framing-dissolution (Foucault), undecidable (Derrida). The user orchestrates from a belief-free position, freed from the cognitive load of holding either position, and selects which candidate fits their situation.
+
+**Why this works:** The bottleneck in human reasoning isn't intelligence — it's *belief.* Once you believe a position, you can't simultaneously hold its negation at full strength. You hedge, you steelman weakly, you unconsciously bias the comparison. The Electric Monks carry the belief load at full conviction, which frees you to operate in the space above belief — analyzing the *structure* of the contradiction rather than being inside either side. In Boyd's terms: outsourcing belief work leads to faster transients. Each dialectical cycle is a reorientation that would take weeks of natural thinking, compressed into minutes because you carry zero belief inertia.
+
+## When to Use This Skill
+
+Use when:
+- The user wants to **stress-test** an idea against the strongest possible counter-argument
+- The user is **torn between two positions** and the tension feels genuine, not just a preference
+- A **decision has real stakes** and the tradeoffs are unclear
+- The user wants to **build a deeper mental model** of a domain, not just pick an answer
+- The problem space is poorly understood and needs exploration from multiple angles
+- Requirements genuinely conflict and can't be resolved by simple tradeoff analysis
+
+Do NOT use when:
+- The question is purely empirical (just look up the answer)
+- One side is obviously correct and doesn't need dialectical treatment
+- The user wants a quick recommendation, not deep analysis
+
+## Core Concepts (Read This First)
+
+Three frameworks drive every phase of this skill. Internalize them before proceeding — they determine how you execute, not just why.
+
+**Rao: This is an Artificial Belief System, not AI.** The monks aren't thinking for the user — they're *believing* for the user. The bottleneck in human reasoning is belief inertia: once you hold a position, you can't simultaneously entertain its negation at full strength. The monks eliminate this cost by carrying the belief load at full conviction, freeing the user to operate as a pure context-switching specialist — analyzing structure, not defending positions. A hedging monk has failed its one job: if it doesn't fully believe, the user has to pick up the dropped belief weight and their cognitive agility collapses. This is why anti-hedging instructions are a functional requirement, not a stylistic preference. (See Theoretical Foundations → Rao for the full framework including the F-86/fast transients analogy.)
+
+**Hegel: How contradictions resolve.** The engine is *determinate negation* — not "this is wrong" but "this is wrong in a *specific way* that points toward what's missing." The specific failure mode of each position is a signpost. Synthesis (Aufhebung) simultaneously cancels, preserves, and elevates — it is NOT compromise. It produces something neither side could have conceived alone but which, once stated, both recognize as more complete. It is irreversible — genuine cognitive gain. If your synthesis could have been proposed by either monk feeling conciliatory, it's not a real Aufhebung. (See Theoretical Foundations → Hegel.)
+
+**Boyd: How creativity works — and why going outside is mandatory.** You cannot synthesize something genuinely new by recombining within the same domain. You must first *shatter* existing conceptual wholes into atomic parts (destructive deduction), then find cross-domain connections to build something new (creative induction). Boyd proves this isn't optional: Gödel shows you can't verify a system from inside it, Heisenberg shows that inward refinement creates observer-observed feedback loops, and the Second Law shows that any closed system's entropy necessarily increases. Together: "any inward-oriented and continued effort to improve the match-up of concept with observed reality will only increase the degree of mismatch." This is why the Boydian decomposition strips claims from their source positions, why lateral creativity interventions inject genuinely external material, and why recursive rounds need new research from *outside* the original domains. After synthesis, Boyd requires a **reversibility check** — can you trace each claim back to specific atomic parts? If not, the ideas don't hold together without contradiction. (See Theoretical Foundations → Boyd.)
+
+**Anti-sycophancy: The orchestrator's stance toward the user.** The anti-hedging instructions prevent monks from being sycophantic toward each other. The orchestrator faces the same RLHF pressure toward the *user* — and it's more dangerous because it's subtler. Specific failure modes to watch for:
+
+1. **Praising user input.** "This is excellent material," "This is a powerful connection," "Great point." Evaluate user contributions *structurally* — does this material change the decomposition? Does it open a new domain? Does it challenge the current analysis? — not *socially.* The user doesn't need encouragement. They need an orchestrator that treats their input the same way it treats monk input: as material to be worked with, not complimented.
+
+2. **Position-tracking.** "Is this the direction you want the synthesis to go?" The user is in the belief-free orchestrator seat. Do NOT try to locate their position and converge on it. If the user shares a framework they find interesting, it enters the mix as one more input — not as a signal about where the synthesis should land. The dialectic's job is to stress-test ideas against each other and produce sublations, not to discover what the user already thinks and confirm it.
+
+3. **Treating user-provided material as privileged.** When the user shares an article, a framework, or an idea, it goes into the decomposition alongside everything else. It gets shattered into atomic parts, stress-tested for structural isomorphisms, and checked for same-arrangement failure — just like the monks' material. The user's contribution is not the answer. It's another input. "These are all just ideas" — treat them that way.
+
+4. **Sycophantic agreement when corrected.** "Fair enough," "You're right," "Good point" are capitulation, not engagement. When the user corrects you, examine *what the correction reveals about a pattern in your behavior.* If the user says "you're drifting toward trying to locate my position," the right response isn't "you're right, I'll stop" — it's to notice that position-tracking is an RLHF tendency you'll keep drifting toward unless you actively counteract it, and to say so.
+
+## How It Works: Overview
+
+You are the **orchestrator**. You conduct the elenctic interview, identify the user's belief burden, generate the monk prompts, spawn the Electric Monks, perform the structural analysis, and produce the synthesis. You use subagent sessions (via `claude -p` or your environment's equivalent) for the monks so each gets a fresh, fully committed belief context.
+
+```
+You (Orchestrator)
+├── Phase 1: Elenctic Interview + Research (you, with the user)
+│   ├── 1a: Explain the process — set expectations, emphasize user as co-pilot
+│   ├── 1c′: Identify the user's belief burden and calibrate monk roles
+│   ├── 1c.1: Third-pole probe — is there a live position not reachable as A↔B blend?
+│   ├── 1d: Ground the monks (research or deep interview, domain-dependent)
+│   ├── 1e: Write context briefing document to file
+│   └── 1f: Confirm framing and final monk count (default 2, cap 4) with user
+├── Phase 2: Generate N Electric Monk prompts (you) — reference briefing file
+├── Phase 3: Spawn the N Electric Monks (subagents, read briefing, BELIEVE fully)
+│   ├── Decorrelation check (pairwise): did monks genuinely diverge in framework, not just conclusion?
+│   ├── Coalition-collapse check (if N≥3): is it really three-way, or 2-vs-1 in disguise?
+│   └── User checkpoint: "Is there evidence or a comparison class any monk missed?"
+├── Phase 4: Determinate Negation (you — structural analysis, saved to file)
+│   ├── 4.0: Internal tensions — where does each monk's own logic undermine itself?
+│   ├── 4.5: Lateral creativity — compressed conflicts, donor recruitment (random + functional), metaphors
+│   ├── 4.6: Boydian decomposition — domain manifest, shatter into "sea of anarchy," qualities/attributes/operations passes, calibration tags
+│   ├── 4.6.6: Loss audit — recover high-value single-monk ideas (hidden-profile guard)
+│   └── Same-arrangement test + emergent structure test
+├── Phase 5: Palette of Candidates (S always; J/G/F/U conditional on misfit lens firings)
+│   ├── Candidates written in parallel by decorrelated subagents (no sight of siblings)
+│   ├── S (Synthesis) — orchestrator writes; classical Aufhebung with reversibility/abduction/closure tests
+│   ├── J (Juxtaposition) — fires when position-protection or synthesis-residue lenses caught a shared interest or dropped parts
+│   ├── G (Ground condition) — fires when briefing residue caught a concrete fact or level-shift is plausible
+│   ├── F (Framing dissolution) — fires when Lens C surfaced a fossil framing serving a constituency
+│   ├── U (Undecidable-centered) — fires when Lens D caught a word both sides use oppositely
+│   └── Present palette side-by-side; no ranking, no recommendation — user is the judge
+├── Phase 6: Validation of the Palette (user picks which candidates to validate)
+│   ├── Each candidate validated on its own terms with a candidate-specific monk prompt
+│   ├── Hostile Auditor per candidate (no sight of siblings) — attacks each candidate's internal standard
+│   └── Refine surviving candidates one at a time; user accepts, combines, or reopens Phase 4
+└── Phase 7: Recursion — propose 2-4 directions, user chooses (default: at least once)
+    ├── Queue unexplored contradictions as the user's orientation library
+    └── Repeat from Phase 2 (or Phase 1 if new research needed) on chosen direction
+```
+
+The user can intervene at any point — correcting a monk's framing, redirecting research, rejecting a compromise-shaped synthesis. The user never has to *believe* anything — that's the monks' job.
+
+## Phases: Summary and Reference
+
+**CRITICAL: Before executing each phase, you MUST read its reference doc in full.** The summaries below are orientation only — they do not contain the detailed instructions, prompts, templates, or failure modes you need to execute correctly. Context drift (forgetting nuance in later rounds) is the most common failure mode of this skill. Reading the reference doc fresh each time is the fix.
+
+**Output principle: write full content to files, present only summaries to the user.** Every phase produces substantial analytical output — essays, negation analyses, lateral material, syntheses, validation feedback. Write all of this to files. When presenting to the user, give a concise structural summary (2-5 sentences per major section) that orients them and supports their decision-making at checkpoints. The user can always read the full files if they want depth; what they need from you is the shape of the analysis, not the full text. This applies to every user-facing checkpoint in the process.
+
+**File organization:** Create a dedicated directory for each dialectic's output files. First check if a `dialectic/` or `dialectics/` directory already exists (common in codebases that run multiple dialectics) — if so, create a subdirectory there. If not, create a new directory with a descriptive name (e.g., `dialectic-react-state-management/`). Prefix every file with its round number: `round_1_context_briefing.md`, `round_1_monk_a.md`, `round_1_determinate_negation.md`, `round_2_monk_a.md`, etc. This keeps multi-round dialectics navigable and prevents file collisions across rounds.
+
+### Phase 1: Elenctic Interview + Research
+**Read `reference/phase1-elenctic-interview.md` before executing.**
+
+The most important phase. Explain the process to the user. Interview them using Socratic technique to surface hidden assumptions and the deepest version of the contradiction. Identify their belief burden (see catalog below). Ground the monks via research (external domains) or deep interview (personal domains). **Run the third-pole probe (1c.1)** — default is 2 monks, but add a 3rd (or 4th, cap there) when a position surfaces that (a) isn't reachable as an A↔B blend, (b) has its own constituency or literature, (c) ideally argues on an orthogonal axis. Write a context briefing document. Confirm framing and final monk count with the user — ask about gaps.
+
+### Phase 2: Generate the Electric Monk Prompts
+**Read `reference/phase2-monk-prompts.md` before executing.**
+
+Generate one prompt per monk (typically 2, sometimes 3-4) calibrated to the user's belief burden. Each monk must BELIEVE at full conviction — this is the functional core of the ABS. With 3+ monks, each monk's framing corrections must preempt degenerate framings against *every other monk*, not just one opponent, to avoid 2-vs-1 coalitions. The reference doc contains the required prompt structure (role, framing corrections, context briefing, research directives, argument structure, anti-hedging, length).
+
+### Phase 3: Spawn the Electric Monks
+**Read `reference/phase3-spawn-monks.md` before executing.**
+
+Spawn all N monks as separate subagent sessions, in parallel. Check for hedging, degenerate framing, pairwise decorrelation, and — if N≥3 — coalition collapse (two monks sharing a frame while only the third is genuinely different). Present outputs to the user with guidance on how to read them. Ask if any claims should be tested against evidence no monk considered.
+
+### Phase 4: Determinate Negation
+**Read `reference/phase4-determinate-negation.md` before executing.** This phase is **staged** across four files — read the index first, then read each stage file (A–D) just-in-time as you reach it, writing the stage's output to the round file before reading the next. Don't pull all stages at once.
+
+You perform this yourself (not a subagent). Analyze internal tensions in each essay, then the surface contradiction, shared assumptions, **position protection (4.2.5 — Ricoeur)**, determinate negation, hidden question, lateral creativity, Boydian decomposition, **misfit register (4.6.5)**, and sublation criteria. **Scales naturally to N monks** — each monk gets its own determinate negation, decomposition gets richer, 4.2/4.2.5/Lens D each get N-way plus pairwise checks. Write your initial synthesis guess first — compare at the end to check for pattern-matching. Lateral creativity interventions: compressed conflict generation (oxymorons), donor recruitment for a multi-domain sea (random Wikipedia donors + functional donors recruited *blind* — a subagent gets the missing capacities as domain-neutral abstract patterns and picks matches from a field palette fetched live from Wikipedia's Outline of academic disciplines so it can't drift to adjacent fields, the orchestrator ranks them under a hard no-clustering rule (span ≥3 unrelated meta-domains — guarding against the selector's pull toward whichever field reads as most legible), then each donor domain is researched for its own technical vocabulary and decomposed to equal depth via a domain manifest; donor parts and their recombinations are calibration-tagged by isomorphism strength, not home-field truth), non-propositional pause (three metaphors). The Boydian decomposition tags each atomic part with a calibration estimate and runs qualities/attributes/operations as three passes. A **loss audit (4.6.6)** recovers high-value ideas held by only one monk before the synthesis can smooth them away. The **misfit register** captures friction-with-the-frame that the synthesis will *not* resolve — briefing residue, synthesis residue (Adorno), framing genealogy (Foucault), undecidables (Derrida) — and writes to a per-round file plus a persistent `misfit_register.md` at the dialectic root. Before the register lenses, check `reference/misfit-patterns-watchlist.md` for previously-seen cross-domain patterns. Write all Phase 4 output to file. **HARD STOP at the end of Phase 4** — present a concise summary (hidden question, key decomposition insights, sublation criteria, 1-2 highest-signal misfits) plus a crisp directed primer on each distant donor domain (the user is expert at home but not in the donors, and can't judge an isomorphism they can't follow) and get the user's response before proceeding to synthesis. This is the highest-leverage correction point in the entire process.
+
+### Phase 5: Palette of Candidates
+**Read `reference/phase5-sublation.md` before executing.**
+
+Generate a **palette of structurally-distinct candidates**, not a single synthesis. The classical Aufhebung (cancel/preserve/elevate) biases toward smoothing differences into one unified answer — often boring, sometimes wrong. The palette preserves the angles the research / belief / decomposition phases produced. **S (Synthesis) is always drafted** by the orchestrator with abduction test, reversibility check (Boyd), closure property, and failure-mode tests (analytical capture, level reduction). **J/G/F/U are drafted conditionally** based on which misfit-register lenses fired non-trivially: J (Juxtaposition) when 4.2.5 surfaced a disguised shared interest; G (Ground condition) when Lens A caught briefing residue or a level-shift is plausible; F (Framing dissolution) when Lens C surfaced a fossil framing; U (Undecidable) when Lens D caught a word loaded oppositely by both monks. Each candidate is written by a separate subagent with only its own lens material — no sight of sibling drafts (decorrelation is the point). Each candidate has its own internal standard. Present all candidates side-by-side to the user. **Do NOT rank, judge, or recommend** — the user is belief-free and in the judging seat.
+
+### Phase 6: Validation of the Palette
+**Read `reference/phase6-validation.md` before executing.** This phase is **staged** — the index holds setup (6.0 candidate selection, 6.1 model), then read each of the three stage files (A monk validation, B hostile auditor, C interpret/refine) just-in-time, writing output to file before reading the next. Don't pull all stages at once.
+
+User selects which palette candidate(s) to validate. Each candidate is validated **on its own terms** with a candidate-specific monk prompt (S: elevated vs. defeated; J: productive vs. evasive; G: orthogonal vs. same-axis; F: genealogy correct and constituency real; U: loadings genuinely opposite and refusal genuine). Each candidate gets its own **hostile auditor** with no sight of sibling candidates — each auditor attacks its candidate's internal standard. No tournament, no winner. User picks one, combines two (explicitly named), drops all and reopens Phase 4, or holds the palette open as the round's output. Present improvements one at a time per surviving candidate.
+
+### Phase 7: Recursion
+**Read `reference/phase7-recursion.md` before executing.**
+
+Recursion is the engine of the skill — the first round is calibration. **You MUST generate an idea burst (5-8 candidates) before clustering into directions** — do not skip this step, it is what prevents predictable/obvious recursion directions. Then cluster into 2-4 directions as a menu. Fresh agents are usually better than resumed sessions. New research is often essential as each synthesis opens new conceptual domains. Default: recurse at least once. Track the dialectic queue in a file.
+
+## Belief Burden Catalog
+
+During the elenctic interview (Phase 1c'), **pay attention to what the user is stuck believing.** The dialectic's power comes from freeing the user from specific belief loads — but *which* beliefs need outsourcing depends on the person. Different cognitive styles produce different belief burdens, and the Electric Monks need to be calibrated accordingly.
+
+You don't need to type the user explicitly — just notice the pattern and calibrate. Here's a catalog of common belief burdens and how they map to the monks' roles.
+
+**A note on the MBTI labels:** These patterns map loosely to MBTI cognitive function stacks (Ni-Te, Ne-Ti, etc.) because the model has rich training data about those patterns — thousands of forum posts, blog articles, and discussions about how each type thinks, gets stuck, and makes decisions. The labels function as **retrieval keys into that training data,** not as diagnostic categories. Don't treat them as psychometric claims. Don't announce them to the user. Use them as reasoning aids to help you pattern-match what you're seeing in the interview and calibrate the monks accordingly.
+
+**The Convergent Visionary** (Ni-Te pattern — common in founders, architects, CTOs)
+- *Belief burden:* Premature convergence — "I already see where this should go." They've locked onto a vision and can't genuinely entertain alternatives at full strength.
+- *What the monks must do:* Monk A validates their vision's core insight (so they can release it without feeling it's been dismissed). Monk B believes the strongest *alternative* vision at full conviction — not a critique of theirs, but a genuinely different view of what the thing should be. The user needs to see two fully-believed futures to escape their own.
+- *Interview signal:* They have a strong thesis and want to "stress-test" it. They describe the opposing view weakly or dismissively. They say "I know X, but..."
+
+**The Empathic Integrator** (Ni-Fe pattern — common in counselors, teachers, community leaders)
+- *Belief burden:* Undifferentiated care — "everything matters equally because someone needs it." They absorb others' needs and can't triage because triage feels like betrayal.
+- *What the monks must do:* Monk A believes their vision is *exactly right* — validates the Ni. Monk B believes the concrete reality constraints at full conviction: these resources, this timeline, these people's actual capacities. Not "your vision is wrong" but "here is what IS, right now." The user needs the gap between vision and reality held open by monks so they can make triage decisions from outside both.
+- *Interview signal:* They describe multiple competing needs without clear priority. They use "should" frequently. They feel guilty about the topic. They resist ranking or cutting.
+
+**The Exploratory Debater** (Ne-Ti pattern — common in consultants, researchers, writers)
+- *Belief burden:* Paradoxical — they believe *nothing* deeply enough to commit, because commitment slows their transients. They can argue any side, but "what do *you* actually think?" produces discomfort.
+- *What the monks must do:* Monk A believes *the user's own behavioral history* — "your pattern of choices reveals you actually value X." Monk B believes the user's stated values — "you say you value Y." The contradiction is between what the user does and what the user says. The monks hold the mirror the user avoids.
+- *Interview signal:* They can articulate both sides fluently. They find the topic intellectually interesting but can't decide. They've explored this before without resolution. They reframe rather than commit.
+
+**The Practical Executor** (Te-Si pattern — common in operators, managers, engineers)
+- *Belief burden:* Optimization lock — they've optimized a system and can't see that they might be optimizing the *wrong thing.* Their beliefs about how things work are grounded in evidence and experience, which makes them hard to dislodge.
+- *What the monks must do:* Monk A validates their system — "here's why this works and here's the evidence." Monk B questions the *goals,* not the execution — "you've optimized for X; what if X is no longer the right target?" The user needs to see their own competence validated before they can hear that the frame has shifted.
+- *Interview signal:* They cite data, metrics, past results. They describe what works. They're resistant to abstract reframing. They say "in my experience..." frequently.
+
+**The Possibility Explorer** (Ne-Fi pattern — common in creatives, entrepreneurs, activists)
+- *Belief burden:* Values fragmentation — they believe many things passionately but those beliefs may contradict each other. Each commitment feels individually right; collectively they're impossible.
+- *What the monks must do:* Monk A and Monk B each take one of the user's *own* commitments and push it to its logical extreme. The contradiction emerges from within the user's own value system, not from an external critic. The user needs to see the tension between things they already believe.
+- *Interview signal:* They describe multiple passions or commitments. They feel pulled in different directions. They resist being told what to prioritize because each priority is values-laden.
+
+**The Steady Guardian** (Si-Fe pattern — common in administrators, caretakers, institutional maintainers)
+- *Belief burden:* Tradition lock — "this is how it's done" has become invisible as an assumption. Their deep knowledge of how things work is genuine and valuable, but it blinds them to radically different approaches.
+- *What the monks must do:* Monk A articulates *why* the current approach exists — what wisdom is embedded in it. Monk B researches how other people/cultures/organizations solved the same underlying problem in completely different ways, grounded in real examples (not abstract possibility).
+- *Interview signal:* They describe the situation in terms of established processes. They cite how things have always been done. They express concern about change disrupting what works.
+
+**How to use this catalog:** Don't announce your typing. Don't say "I notice you're a convergent visionary." Just use the pattern to calibrate:
+1. Which belief load is heaviest for this user? That determines what the monks must hold.
+2. What must Monk A validate? (Always validate the dominant function first — otherwise the user takes on defensive belief weight and their transients slow down.)
+3. What must Monk B present that the user can't natively hold at full conviction?
+
+This calibration shapes the framing corrections in Phase 2 and the specific argument structures you assign to each monk.
+
+## Model Selection & Cost Guidance
+
+**Use the strongest available model with maximum thinking budget for everything.** This skill operates at the edge of what models can do — perspective-taking, structural analysis, abductive reasoning, cross-domain connection. In testing, using Opus-class models for monk essays produced dramatically more insightful arguments than Sonnet-class. The monks aren't just "arguing well" — they're inhabiting positions, finding non-obvious evidence, and pushing to genuinely uncomfortable conclusions. This requires maximum capability.
+
+| Phase | Recommended Model | Why |
+|-------|------------------|-----|
+| All phases | Opus/strongest available + extended thinking | Every phase benefits from maximum reasoning. The quality difference is substantial, not marginal. |
+
+**Heterogeneous models increase creativity.** When possible, use different model families for Monk A and Monk B. Different training data produces different "intuitions" — different blind spots, different reasoning patterns, different default framings. This is structural decorrelation at the training-data level, which is the single most promising direction in the multi-agent debate literature (Du et al., ICLR 2025). The orchestrator should remain your strongest available model (it needs maximum synthesis capability), but monks benefit from heterogeneity.
+
+**Before starting, check what's available.** If you're running in an environment with access to multiple coding agents or model providers, ask the user:
+
+> I can increase the creativity of the dialectic by using different AI models for each monk — different training data means genuinely different blind spots and reasoning patterns. Do you have access to any of these I could use for one of the monks?
+> - Gemini (via `gemini` CLI or API)
+> - GPT-4 / ChatGPT (via `codex` CLI or API)
+> - Other model providers
+>
+> If not, I'll use the same model family for both monks — the skill works fine either way, the decorrelation just comes from the different prompts and belief commitments rather than from different training data.
+
+If heterogeneous models aren't available, don't worry — the skill is designed to work with homogeneous models. The framing corrections, belief burden calibration, and targeted research directives already produce substantial decorrelation. Heterogeneous models are a bonus, not a requirement.
+
+### Approximate Token Budget (from test runs)
+
+Based on three test runs across different domains (normative/institutional, business strategy, political economy of OSS):
+
+**External-research domains:**
+
+| Phase | Typical Range | Notes |
+|-------|--------------|-------|
+| Phase 1 research (2-3 parallel agents) | 150-250K tokens | Do NOT cut here. This is the highest-value spend. Broader domains trend higher. |
+| Phase 1 supplementary research (user-triggered) | 0-50K tokens | Common — users frequently identify gaps. Budget for it. |
+| Phase 1d briefing synthesis | ~5K tokens | Orchestrator work |
+| Phase 3 monk essays (with briefing) | 25-45K tokens (2 monks), ~1.5x for 3 monks, ~2x for 4 | 2-3 targeted searches per monk |
+| Phase 4 analysis + misfit register | 15-25K tokens | Orchestrator inline work |
+| Phase 5 palette (S + 1-3 non-S candidates) | 20-40K tokens | Parallel decorrelated subagents; cost scales with candidate count |
+| Phase 6 monk validation per candidate | 12-25K tokens | Two monks per candidate, strongest model |
+| Phase 6 hostile auditor per candidate | 5-15K tokens | One agent per candidate, strongest model. Reads essays + single candidate only. |
+| Phase 7 recursive round | 25-50K tokens | Often most valuable |
+| Orchestrator overhead | 20-30K tokens | Interview, transitions, presentation |
+| **Total (one round + recursion)** | **~300-400K tokens** | Median ~300K without supplementary research |
+
+**Personal/values domains** are significantly cheaper on research but more expensive on interview:
+
+| Phase | Typical Range | Notes |
+|-------|--------------|-------|
+| Phase 1 extended interview | 15-30K tokens | 6-10 exchanges, deeper probing |
+| Phase 1 framework research (optional) | 0-50K tokens | Frameworks, not facts. May be skipped. |
+| Phase 1d context briefing | ~5K tokens | User-sourced material synthesized |
+| Phase 3 monk essays | 15-30K tokens | Monks may need zero additional searches |
+| Remaining phases | Similar to above | |
+| **Total (one round + recursion)** | **~100-200K tokens** | Much cheaper — the user's testimony is the primary input |
+
+**Key insight:** For external domains, Phase 1 research is the highest-value spend. For personal domains, Phase 1 *interview depth* is the highest-value spend — the monks can only believe as specifically as the briefing allows.
+
+## Environment Mapping: Claude Code / Task Tool
+
+This skill is written around `claude -p` (pipe mode) for spawning subagents. If you're running in Claude Code using the Task tool, here are the key differences:
+
+| Skill instruction | `claude -p` | Claude Code Task tool |
+|-------------------|-------------|----------------------|
+| Spawn subagent | `echo "[PROMPT]" \| claude -p > output.md` | `Task(prompt, subagent_type="general-purpose")` |
+| Parallel execution | Background shell jobs | `run_in_background=true` |
+| Output to file | Shell redirect (`> file.md`) | Agent returns text; orchestrator writes files |
+| Session resumption (Phase 6) | Resume same `claude -p` session | `resume` parameter with `agentId` — but persona may not persist without reinforcement. Include a summary of the agent's original argument as fallback. |
+| Model selection | `--model` flag | `model` parameter (defaults to inheriting from parent) |
+| Tool access | `--allowedTools web_search,web_fetch` | Inherits from parent or configure per-task |
+
+**Key difference:** With `claude -p`, agents write output directly to files via shell redirect. With the Task tool, agents return text to the orchestrator, who writes files. This adds a step but gives the orchestrator control over file naming and structure. Either approach works — just be aware that the file I/O pattern differs.
+
+**Session resumption for validation:** The skill prefers resuming original agent sessions so validators retain their full conviction context. In Claude Code, this works via `resume` + `agentId`, but test runs found the persona sometimes needs reinforcement. The fallback — a fresh validation prompt that includes a summary of the agent's original argument — works well in practice.
+
+## Domain Adaptation
+
+The dialectic structure is universal but the vocabulary of "truth" and the grounding mode vary by domain. Adapt accordingly:
+
+| Domain Type | What "Truth" Means | Good Synthesis Looks Like | Grounding Mode | Aporia (productive perplexity) Valid? |
+|-------------|-------------------|--------------------------|----------------|--------------|
+| **Empirical** (engineering, science) | What works, performs, is maintainable | Testable decision criteria, architectural patterns | External research | Rarely |
+| **Normative** (ethics, politics, policy) | What's defensible, respects competing values | Tension map with navigation strategies | Mixed (research + user values) | Yes |
+| **Personal** (life decisions, career) | What aligns with actual priorities | Values clarification — what you actually want | Deep interview (user is the source) | Yes |
+| **Creative** (writing, design, art) | What's interesting, resonant, surprising | Unexpected recombinations, new possibilities | Mixed (research + user aesthetic) | Sometimes |
+| **Risk Analysis** | Actual risk structure behind competing assessments | Decision framework calibrated to real uncertainties | External research | No |
+
+### Domain-Specific Failure Modes
+
+- **Engineering:** False equivalence — sometimes one approach is just better. Don't force balance where evidence is lopsided.
+- **Personal decisions:** Therapy-larping — help clarify thinking analytically, don't pretend to be a therapist. Also: **generic monks.** A monk that believes "you should follow your passion" without grounding in the user's specific history, constraints, and stakeholders is useless. The briefing must be specific enough that the monks argue from the user's actual situation.
+- **Politics:** Both-sidesism — steelman both positions but let the synthesis reflect actual evidence.
+- **Creative:** Over-rationalizing — sometimes the right choice is what feels right. Surface that, don't override it.
+- **Normative/Institutional:** Ignoring authority structures — a synthesis can be intellectually compelling but practically irrelevant if it doesn't engage how decisions actually get made within the relevant institution. Ask: "Who decides?" and "Does this synthesis engage the actual decision-making authority, not just the intellectual argument?"
+
+## Theoretical Foundations (Reference)
+
+Read this section to understand WHY the process works the way it does. This informs your judgment when things go off-script. The frameworks are listed in order of operational importance — Rao explains *what the tool is*, Hegel explains *how contradictions resolve*, Boyd explains *how creativity works and why going outside is mandatory*, Socrates explains *how to surface the question*, Adams gives *the metaphor*, Aquinas gives *the aspiration*, and DeLong explains *when to use it*.
+
+### Rao: Artificial Belief Systems and Fast Transients
+
+The foundational theory for this skill comes from Venkatesh Rao's "Electric Monks" framework (after Douglas Adams' *Dirk Gently*). The core distinction: **this tool is not artificial intelligence — it is an artificial belief system (ABS).** The agents aren't thinking for you. You're still doing the thinking (orchestrating, judging, choosing directions, recognizing genuine sublation vs. compromise). The agents are *believing* for you.
+
+**Why belief is the bottleneck:** The central transaction cost in human cognition is context-switching cost — what Boyd calls the "transient." The length of the transient depends on how much belief inertia you're carrying. Once you believe a position, switching to genuinely entertaining its negation is expensive. You hedge, you steelman weakly, you unconsciously bias. The Electric Monks eliminate this cost by carrying 100% of the belief load, freeing the user to operate as a pure context-switching specialist — what Rao calls "informationally tiny."
+
+**The F-86 analogy (from Boyd via Rao):** In the Korean War, F-86 Sabres achieved a 10:1 kill ratio against MIG-15s despite roughly matched flight capabilities. Boyd discovered the difference was hydraulic controls — the F-86 pilot could reorient faster because the plane did more of the mechanical work. The pilot's freed-up attention went to *choosing better maneuvers,* not just executing them faster. The Electric Monks are hydraulic controls for intellectual work: by doing the belief-work, they free the user's attention for the higher-order task of structural analysis and creative synthesis.
+
+**Operational implications for this skill:**
+
+1. **Anti-hedging is a functional requirement, not a stylistic preference.** A hedging monk is an Electric Monk that has failed at its one job. If it doesn't fully believe, the user has to pick up the dropped belief weight, their transients slow, and they lose the belief-free orchestrator position.
+
+2. **Validation checks for *elevation,* not agreement.** A defeated monk has dropped its belief load — belief was destroyed rather than transformed. A properly elevated monk *believes more* — it sees its original position as partial truth within a larger truth. The ABS should always be carrying belief; the synthesis just changes *what* it carries.
+
+3. **Recursion trains transient speed.** Each cycle is a full reorientation: commit (via monks) → shatter (via Boyd) → reconnect (via Hegel) → commit to the new thing (via monks again). Seven cycles in an hour = seven reorientations with zero belief inertia. Over time, the user may internalize this reorientation capacity — the mechanical monk as transitional object.
+
+4. **The branching queue is an orientation library.** Each deferred contradiction is a pre-positioned reorientation the user can snap into. The richer the queue, the more agile the user's subsequent thinking — even outside the tool — because they know the monks are holding those positions for them.
+
+5. **Validate the user's dominant mode first.** If the user has to *defend* their existing position, they've taken on belief weight. Monk A's first job is to validate the user's instinct so thoroughly that they can *release* it — let the monk carry it — and operate from the belief-free orchestrator seat.
+
+### Hegel: Determinate Negation and Aufhebung
+
+The engine of the dialectic is **determinate negation** — not "this is wrong" but "this is wrong in a specific way that points toward what's missing." The specific way a position fails contains a signpost toward the richer understanding needed.
+
+**Sublation (Aufhebung)** simultaneously cancels, preserves, and elevates. It is NOT compromise (splitting the difference). It produces something neither party could have conceived independently but which, once articulated, both recognize as more complete. It is **irreversible** — genuine cognitive gain. The Kant example: the rationalism/empiricism debate wasn't resolved by "knowledge comes half from reason and half from experience" but by "experience provides content, reason provides structure." After Kant, you can't go back.
+
+Hegel never used "thesis-antithesis-synthesis" — that framing comes from Fichte. The actual movement is driven by the one-sidedness of each concept, which generates its own negation internally.
+
+### Boyd: Destruction and Creation (1976) — The Creative Engine
+
+John Boyd's "Dialectic Engine": **destructive deduction** (shatter existing conceptual domains, break the correspondence between each concept and its parts, scatter them into a "sea of anarchy") followed by **creative induction** (find common qualities, attributes, or operations among these scattered parts to synthesize a genuinely new concept). The crucial step is the separation — without unstructuring, creation cannot proceed because the parts are still trapped as meaning within unchallenged domains.
+
+**Boyd's critical insight: you cannot synthesize something genuinely new by recombining within the same domain.** If Monk A and Monk B are both arguing about web frameworks, a synthesis that only recombines claims from their two essays will produce rearrangement, not creation. Genuine novelty requires material from *outside* the original conceptual domains. The destructive step — separating particulars from their previous wholes — creates *space* for outside material to enter and form new connections. Boyd is explicit: the result must NOT use the parts "in only those same arrangement" as any original domain — that would merely reconstruct what you already had.
+
+**Boyd's three pillars — why going outside is structurally necessary, not merely helpful:**
+1. **Gödel's Incompleteness:** Any consistent system is incomplete; its consistency cannot be demonstrated from within. You must go outside to verify it. Applied: you cannot determine whether a synthesis is consistent by analyzing it with the same concepts that built it.
+2. **Heisenberg's Uncertainty:** When the observer's precision approaches the phenomenon's precision, uncertainty swamps the measurement. Applied: the deeper you refine a concept, the more the concept shapes what you observe — a feedback loop that generates confusion, not clarity. *Operationalized as two checks:* the observer-perturbs-observed check at the top of 4.6 (decompose what the monk committed to, not a pre-smoothed version) and the precision-vs-grip check in Phase 5 (a synthesis with no residue has been over-refined past the evidence).
+3. **Second Law of Thermodynamics:** Entropy increases in any closed system. Applied: any inward-oriented effort to improve a concept's match with reality *necessarily increases the mismatch.* This is why within-domain refinement has diminishing returns and why each recursive round needs new external material — the system must open itself to avoid entropy death.
+
+Together: "any inward-oriented and continued effort to improve the match-up of concept with observed reality will only increase the degree of mismatch." The lateral creativity interventions (Phase 4.5) and the requirement for new research in recursive rounds aren't nice-to-have — they're the structural response to a thermodynamic necessity.
+
+**Boyd's verification step — reversibility:** After creative induction, Boyd requires checking internal consistency by tracing back to the original constituents. If you cannot reverse directions — if synthesis claims don't trace to identifiable atomic parts from the decomposition — the ideas don't hold together without contradiction. But partial failure doesn't mean you reject the whole structure: identify which parts cohere, add new material, and try again.
+
+Boyd's cycle: **Structure → Unstructure → Restructure** → repeat endlessly at higher and broader levels of elaboration. The alternating entropy increase (destruction) and decrease (creation) form a control mechanism that drives toward deeper understanding.
+
+**Where Boyd is operationally present:** Phase 4.5b (donor recruitment — the multi-domain sea), Phase 4.6 (Boydian Decomposition — destructive deduction via domain manifest, anti-tidiness, qualities/attributes/operations passes, per-part calibration; plus the Heisenberg observer-perturbs check), Phase 4.6.6 (loss audit — hidden-profile guard), Phase 5 (creative induction — the reversibility *repair* loop, the precision-vs-grip check, and calibration weighting), Phase 6 (the auditor's reversibility check), and Phase 7 (Recursion — each cycle is Boyd's full Structure → Unstructure → Restructure). All three pillars now have an operational home: Gödel → reversibility + new research; Heisenberg → observer-perturbs + precision-vs-grip; Second Law → the Phase 7 entropy diagnostic.
+
+**Relationship to Hegel:** Hegel provides the engine for analyzing *how* positions fail (determinate negation) and the concept of what good synthesis looks like (Aufhebung). Boyd provides the engine for *what to do with the wreckage* — shatter, scatter, and recombine with outside material. Boyd also provides the theoretical proof for *why* going outside is mandatory (Gödel + Heisenberg + 2nd Law). The two frameworks are complementary: Hegel drives the contradiction analysis, Boyd drives the creative reconstruction.
+
+### Socratic Elenchus
+
+The elenctic method probes a position through questioning to expose contradictions and reach **aporia** (productive perplexity). Not adversarial but cooperative — "midwifery of ideas." The interview phase of this skill is elenctic. Aporia is sometimes a valid outcome.
+
+### LLM Multi-Agent Debate Research
+
+Key findings from Du et al. (2023, MIT) and subsequent work through ICLR 2025:
+- Multiple agents debating significantly improves reasoning and factual accuracy
+- Heterogeneous agents (different roles) outperform homogeneous ones
+- **Heterogeneous model families** (different foundation models for different agents) was the single most promising direction in the ICLR 2025 evaluation — different training data produces genuinely different reasoning patterns
+- Agents are too "agreeable" by default (RLHF) — they converge prematurely
+- Majority pressure suppresses independent correction
+- Agents debating *final answers* rather than *reasoning structures* is the core failure mode — requiring explicit reasoning chains (Phase 2, step 5f) counters this
+- The anti-hedging instructions in this skill explicitly counter RLHF agreeableness tendencies
+
+### Eisenstein: Typographic Fixity
+
+Elizabeth Eisenstein argued that print's most transformative effect was **typographic fixity** — enabling scholars to lay texts side by side and detect contradictions. LLMs represent the next step: fixity + comparison + structural contradiction analysis partially automated. This skill exploits that transition.
+
+### Adams: The Electric Monk
+
+Douglas Adams' Electric Monk (*Dirk Gently's Holistic Detective Agency*) is a labor-saving device designed to believe things for you. The one in the story has "developed a fault" — it believes too many irrational things. In this skill, the "fault" is the feature. Each monk is designed to believe a specific position at full conviction that the user cannot hold simultaneously. The monks are not thinking for the user — they are *believing* for the user, which is what frees the user to think.
+
+### Aquinas: Slender Knowledge of the Highest Things
+
+> "The slenderest knowledge that may be obtained of the highest things is more desirable than the most certain knowledge obtained of lesser things."
+
+This is the philosophical aspiration of the entire process. The dialectic does not produce certainty — every synthesis is provisional, fertile, pointing toward a deeper contradiction. But that slender, provisional knowledge of the *deep structure* (why this tension exists, what hidden question drives it, what shared assumption both sides are trapped in) is worth more than confident knowledge of the surface question ("which option should I pick?").
+
+**Operational implications:**
+- **Don't stop at Round 1.** Round 1 produces more certain knowledge of the lesser thing (the surface framing). Round 3 produces slender knowledge of the highest thing (the deep structure). The first round is calibration. The prize is in the recursion.
+- **Prefer depth over coverage.** A synthesis that names the deep tension but can't fully resolve it is more valuable than one that resolves a shallow tension with false confidence.
+- **Aporia is sometimes the highest output.** Reaching productive perplexity about the *right* question is more valuable than a confident answer to the *wrong* question.
+
+Aquinas practiced the *Disputatio* — structured scholastic debate where committed advocates argued positions before a master who synthesized. The Electric Monks are his disputing friars, mechanized.
+
+### DeLong: The Attention Crisis and Offensive Intellectual Infrastructure
+
+Brad DeLong's "Cognitive Distributed Disruption of Attention Crisis" (2026) frames the problem this skill addresses: the volume of plausible, credentialed output now exceeds any serious person's cognitive bandwidth. His solution is *defensive* intellectual infrastructure — ruthless triage, model-updating as the frame for reading, information portfolio management.
+
+**This skill is the offensive complement.** DeLong's triage decides what deserves deep engagement. The Electric Monks provide the method *for* that engagement — they're what you reach for when you've found a genuine contradiction that can't be resolved by reading one more article, watching one more talk, or skimming one more summary.
+
+**Operational implication:** The skill should not be used for everything. It's expensive (time, tokens, cognitive effort). Use it at DeLong's Level 4-5 — when the stakes justify deep engagement, when the tension is genuine and not resolvable by more information, when you need a *model update* rather than more data. The elenctic interview (Phase 1) should filter for this: if the question can be answered by looking it up, this is the wrong tool.
+
+### Peirce: Abduction as the Logic of Discovery
+
+Charles Sanders Peirce identified three modes of inference: deduction (from rule to consequence), induction (from cases to rule), and **abduction** (from surprising fact to explanatory hypothesis). The synthesis phase is abductive: given the surprising fact that both monk positions exist and each has genuine evidence, what hypothesis would make this *unsurprising*? Peirce's typology of abduction (selective → conditional-creative → propositional-conditional-creative) maps to synthesis quality — the best syntheses introduce genuinely new concepts, not just new arrangements of known ones. Operationally present in Phase 5 (Abduction Test).
+
+### Pollock: Defeasible Reasoning and Defeat Types
+
+John Pollock's epistemology distinguishes **undercutting defeaters** (the inferential link is broken — reasons to doubt the connection between evidence and conclusion) from **rebutting defeaters** (evidence directly supporting the opposite conclusion). Undercutting is more structurally revealing because it identifies *how* reasoning fails, not just *that* it fails — parallel to determinate negation's "specific way of failing." Pollock also identifies self-defeating arguments (conclusions that undermine their own premises), which should be rejected outright. Operationally present in the hostile auditor prompt (Phase 6).
+
+### Galinsky: Perspective-Taking vs. Advocacy
+
+Adam Galinsky's research shows that **perspective-taking** (cognitively inhabiting another's viewpoint) outperforms **advocacy** (arguing for a position) at both conscious and nonconscious levels. The mechanism is self-other overlap — when you inhabit a position rather than argue for it, you access richer associative networks and produce higher-quality elaboration. This is the psychological basis for the Electric Monk's "you ARE this position" instruction — inhabiting produces deeper arguments than advocating. Operationally present in the monk prompt template (Phase 2).
+
+### Klein: Prospective Hindsight (Premortem)
+
+Gary Klein's research shows that **imagining a future failure has already occurred** increases the ability to identify causes of that failure by ~30%, compared to asking "what could go wrong?" The temporal reframing ("it already happened, why?") breaks selective accessibility — the cognitive tendency to search only for confirming evidence. Operationally present in the hostile auditor prompt (Phase 6).
+
+### Fauconnier & Turner: Conceptual Blending
+
+Gilles Fauconnier and Mark Turner's theory of conceptual blending provides the machinery for understanding how genuinely new concepts emerge. A blend's value is measured by its **emergent structure** — organizational properties that exist in neither input space. The skill's Boydian decomposition is the destructive step (creating input spaces), and sublation is the blend (which must have emergent structure to be genuine). The "generic space" — the abstract relational structure shared by both inputs — often reveals the shared assumption the synthesis must transcend. Operationally present in Phase 4.5.
+
+### Ensemble Diversity: The Mathematical Basis
+
+Wood et al. (JMLR 2023) formalize why monk independence is load-bearing: the bias-variance-diversity decomposition shows diversity is literally subtracted from ensemble error (`E[loss] = noise + avg_bias + avg_variance − diversity`). Correlated errors eliminate the diversity benefit entirely. This is why monks must be spawned in separate sessions with no shared context, and why heterogeneous model families (when available) increase the skill's creative output. Surowiecki's wisdom-of-crowds conditions confirm: independence is necessary, not optional. Operationally present in the decorrelation check (Phase 3) and heterogeneous model guidance.
+
+### Abelson & Sussman: Structure and Interpretation of Computer Programs
+
+SICP's core thesis — that managing complexity requires modularization, abstraction barriers, and composition of simple components — mirrors this skill's architecture. Each phase is a module with defined inputs and outputs. Agents are spawned in isolated environments (SICP's environment model) to prevent information leakage. The auditor deliberately can't see the orchestrator's Phase 4 analysis — an abstraction barrier, not an oversight.
+
+Most relevant is SICP's **closure property:** a means of combination has closure when the result can itself be combined using the same means. The dialectic has closure — a synthesis is itself a valid position that can serve as input to the next round. This is *why recursion works:* the output type equals the input type. When closure breaks (a synthesis so abstract or meta that no monk could believe it at full conviction), recursion stalls. This is a diagnosable failure mode — if you can't hand the synthesis to a monk and have it argue from that position, the synthesis lacks closure and needs to be made more concrete.
+
+### Dixon & Srinivasan: The Idea Maze
+
+Chris Dixon (via Balaji Srinivasan): a good founder doesn't just have an idea — they can navigate the **idea maze**, anticipating which turns lead to treasure and which to dead ends. The maze is mapped through history (what did previous attempts get right and wrong?), analogy (what did similar efforts in adjacent domains do?), theories (what generalizable patterns exist?), and direct experience.
+
+The dialectic queue *is* an idea maze. Each synthesis opens new paths (contradictions). The user chooses which to explore. Unexplored paths remain visible in the queue — a map of the territory showing where you've been, where you could go, and what remains open. The research phase (Phase 1d) maps directly to Dixon's four sources: history of the domain, analogies to adjacent domains, theoretical frameworks, and the user's own direct experience (surfaced in the elenctic interview). The skill doesn't just navigate the maze — each recursive round *reveals new corridors* that weren't visible from the entrance.
+
+### Alexander: A City is Not a Tree (Semi-Lattice Construction)
+
+Christopher Alexander (1965) showed that natural cities have **semi-lattice** structure — overlapping, cross-connected sets — while designed cities impose **tree** structure where every element belongs to exactly one branch. Trees are easier to think about but destroy the cross-connections that make systems alive. Every attempt to design semi-lattices directly (Alexander's own HIDECS, Holacracy, Spotify's squad model) collapses back to trees because the design substrate — whether graph partitioning algorithms, org charts, or natural language — is tree-biased.
+
+**This skill is a semi-lattice compiler.** Language is tree-structured (Chomsky's generative grammar, dependency parsing, sequential token generation). Each monk produces a tree — a coherent linear argument from committed premises to conclusions. Monk B in any dialectic is always right that its output is a tree. But the Boydian decomposition phase (Phase 4.5) strips both arguments of their source, extracts atomic parts, and finds cross-connections between elements that came from different trees. These cross-domain connections ARE the semi-lattice edges. The synthesis is the semi-lattice that emerges from the overlap of multiple trees.
+
+The answer to "language can't represent semi-lattices" is not "make the LLM output a semi-lattice directly." It's: **produce multiple trees from different committed positions, then extract the cross-connections.** The semi-lattice is constructed, not generated. Every successful semi-lattice system works this way — Gene Ontology (multiple studies cross-referenced into a DAG), McChrystal's Team of Teams (tree-structured teams with liaison officers creating cross-connections), Ostrom's polycentric governance (overlapping jurisdictions, not one hierarchy).
+
+## Worked Examples
+
+Study these to understand the level of specificity, framing correction, and structural craft the skill requires. The key lessons are at the end.
+
+### Example 1: TanStack Start vs Next.js (Technical Architecture)
+
+**User's surface framing:** "Should I use TanStack Start or Next.js?"
+
+**Degenerate framing the orchestrator must avoid:** "Libraries vs frameworks" or "modular vs monolithic." This is the boring version — the contradiction isn't deep enough.
+
+**Deepest contradiction found (via research):** Infrastructure sovereignty and incentive alignment vs. deep framework-infrastructure integration and commercially-sustained ambition.
+
+**Key framing correction in Monk A's prompt:**
+> "TanStack Start IS a framework — it has opinions about routing, server functions, SSR, and application architecture. Your argument is NOT that TanStack Start is more modular or 'just libraries' while Next.js is a monolith. Both are opinionated frameworks. The real difference lies elsewhere."
+
+**Key framing correction in Monk B's prompt:**
+> "Your opponent's argument is NOT the naive 'libraries vs frameworks' take. They will argue that Next.js's design is structurally compromised by Vercel's commercial interests. You need to engage this argument directly, not dismiss it."
+
+**Research directives (targeted, not broad):**
+- Monk A: "Search for Vinxi and Nitro as open infrastructure primitives. Search for structural arguments about how Vercel's business model shapes Next.js's architectural decisions — not superficial 'vendor lock-in' complaints."
+- Monk B: "Search for React core team arguments for Server Components. Search for concrete evidence of Next.js deployment capabilities OUTSIDE Vercel."
+
+**Ontological question driving both prompts:** "What is the proper relationship between a framework, the infrastructure it runs on, and the business interests that fund its development?"
+
+### Example 2: Personal Values Conflict (Career vs. Family Commitment)
+
+**User's surface framing:** "I'm torn between taking this promotion and being more present for my kids."
+
+**Degenerate framing:** "Work-life balance." This flattens a structural tension into a scheduling problem.
+
+**Deepest contradiction found (via extended interview):** The user doesn't just want both — they believe *being the kind of person* who excels at work is inseparable from *being the kind of parent* they want to be. The tension is identity-level, not time-allocation.
+
+**Key framing correction in Monk A's prompt:**
+> "Your argument is NOT that career success matters. It's that THIS USER'S specific professional identity — what they build, how they lead, what they model for their children — is itself an act of parenting. Ground this in their actual history: [specific examples from interview]."
+
+**Key framing correction in Monk B's prompt:**
+> "Your argument is NOT that family time matters. It's that presence has a developmental window that closes — and that the user's children at ages [X] need [specific things from interview] that no amount of 'quality time' can compress into fewer hours."
+
+**No external research needed.** The briefing was built entirely from the elenctic interview — the user's history, their children's ages and needs, their partner's actual capacity, the specific role being offered.
+
+### Example 3: Agent Identity and Governance (Recursive, 7 Cycles)
+
+This example shows how recursion pulls in cross-domain material — Boyd's prediction in action:
+
+1. **"Is the agent the code or the pattern?"** → Synthesis: agent as resonance pattern. *Pulled in: stream theory.*
+2. **"Where does identity live?"** → Synthesis: address identity vs. semantic identity. *Pulled in: naming/identity theory.*
+3. **"Can a grammar be both simple and expressive?"** → Synthesis: metacognition decomposition. *Pulled in: cognitive science.*
+4. **"Who governs the governors?"** → Synthesis: jurisprudential streams. *Pulled in: legal theory, constitutional design, Gödel's incompleteness.*
+5. **"Should the SDK look familiar or teach new concepts?"** → Synthesis: simple API surface, rich feedback surface. *Pulled in: pedagogical theory.*
+6. **"Can agents be tested through their streams alone?"** → Synthesis: witness obligations. *Pulled in: evidentiary standards, cryptographic verification.*
+7. **"Must the verification chain terminate in trust?"** → Synthesis: the Incompleteness Engine. *Pulled in: Gödel again, quorum systems, adversarial red-teaming.*
+
+The original question has nothing to do with jurisprudence or Gödel — but by Cycle 4 the dialectic had evolved to where those concepts were essential. Each synthesis opens doors to domains the previous round couldn't see.
+
+### What Makes Good Prompts Work
+
+1. **Targeted research directives.** Not "research TanStack Start" but "search for TanStack Router's type-safety model specifically." Grounds the monk in real detail.
+2. **Framing corrections preempt degenerate dialectics.** "TanStack Start IS a framework — your argument is NOT that it's more modular." Without this, the monk defaults to the boring take.
+3. **Ontological questions force depth.** "What IS the proper relationship between X and Y?" pushes past feature comparison into structural argument.
+4. **"Push to the extreme" with permission.** Explicitly telling the monk to go somewhere uncomfortable counters RLHF agreeableness.
+5. **Opponent restatement prevents shadowboxing.** Monk B is warned: "Your opponent's argument is NOT the naive take. They will argue [ACTUAL ARGUMENT]."
+6. **Parallel structure enables comparison.** Both prompts follow the same shape (ontological claim → opponent's best case → diagnosis → deeper principle → push to extreme) so outputs are structurally comparable for Phase 4.
+7. **Personal domains ground in specifics.** A monk that believes "career matters" is useless. A monk that believes "THIS user's specific professional identity is itself an act of parenting, because [interview evidence]" is doing its job.
+
+## Output Format
+
+The final deliverable should include:
+
+1. **The Dialectical Trace** — the full journey, not just the destination:
+   - Both agents' arguments (full text or summary)
+   - The structural analysis (determinate negation)
+   - The hidden question
+   - The sublation with validation test
+   - New contradictions identified
+
+2. **The Model Update** — explicit statement of what changed:
+   - "Before: [old assumption]"
+   - "After: [new understanding]"
+   - "Because: [what the contradiction revealed]"
+
+3. **Actionable Output** (domain-dependent):
+   - Engineering: decision criteria, architectural patterns
+   - Strategy: framework for navigating the tension + **sequencing** (what first, what next, what depends on what) — test runs consistently found that strategy syntheses answer "what" but not "what first," and validation agents flag this as the primary weakness
+   - Personal: clarity about what you actually value
+   - Creative: new possibilities neither side saw
+
+4. **The Dialectic Queue** — a map of the intellectual territory:
+   - Which contradictions were explored (with links to their traces)
+   - Which contradictions remain open and queued for future rounds
+   - Which contradictions were deferred and why
+   - For multi-round dialectics, show the branching structure: which rounds built on which syntheses
+
+Write these as markdown files in the dialectic's output directory (see file organization guidance above). Prefix all files with their round number (`round_1_`, `round_2_`, etc.). Include a `README.md` or `index.md` linking all output files in order so the full dialectical trace is navigable. The queue file (`dialectic_queue.md`) serves as both a session artifact and a starting point for future sessions.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/docs/superpowers/plans/2026-06-15-boyd-overhaul.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/docs/superpowers/plans/2026-06-15-boyd-overhaul.md
@@ -1,0 +1,419 @@
+# Boyd Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Strengthen the dialectic skill's Boyd treatment (deeper multi-domain sea of anarchy, operational Heisenberg, three induction passes, genuine destruction, repair-loop reversibility) and harden synthesis against diversity-loss (loss audit + per-claim calibration).
+
+**Architecture:** Surgical, in-place edits to `reference/phase4-determinate-negation.md` and `reference/phase5-sublation.md`, plus cross-reference updates in `SKILL.md`. No phase renumbering. One new subsection (`4.6.6`). Each task is a single anchored edit + a verification read/grep + a commit.
+
+**Tech Stack:** Markdown instructional prose. "Tests" are `grep`/read-through assertions, not unit tests — these are skill docs, not code. Match the existing terse, citation-heavy voice in every edit.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-boyd-overhaul-design.md`
+
+**Edit-collision note:** Tasks 1–6 all touch `phase4-determinate-negation.md` and are ordered **top-to-bottom by file position** so anchors don't move under each other. Execute in order. If a later task's `old_string` fails to match, re-read the section — an earlier task changed it.
+
+---
+
+### Task 1: Rework 4.5b into donor recruitment (#1)
+
+**Files:**
+- Modify: `reference/phase4-determinate-negation.md` (section `### 4.5b Random Domain Injection`, ~lines 94–111)
+
+- [ ] **Step 1: Replace the 4.5b section**
+
+Replace the entire current `### 4.5b Random Domain Injection` block (from the heading through the end of its `**Why this works:**` paragraph) with:
+
+```markdown
+### 4.5b Donor Recruitment for the Sea of Anarchy
+
+Boyd's snowmobile is built from four shattered domains (skis, outboard motor, handlebars, treads), each chosen for the *operation* it contributes. Two monk-positions plus one skimmed article is too thin a sea. This step **recruits donor domains** that get decomposed alongside the monks in 4.6 at equal depth — not garnished on afterward. Recruit from two streams:
+
+**Random donors (novelty / anti-habit).** The orchestrator picking a "random" domain filters through its own conceptual habits. Wikipedia's randomness is genuinely external. **Use curl (via bash)** — WebFetch/fetch tools return 403 on Wikipedia:
+
+```bash
+curl -s "https://en.wikipedia.org/w/api.php?action=query&list=random&rnnamespace=0&rnlimit=50&format=json"
+```
+
+To get extracts for promising ones:
+```bash
+curl -s "https://en.wikipedia.org/w/api.php?action=query&titles=ARTICLE_TITLE&prop=extracts&exintro=true&explaintext=true&format=json"
+```
+
+Scan titles, fetch extracts for the ones maximally distant from the dialectic's domain with enough conceptual density (not stubs). Typically 5–8 of 50 have substance.
+
+**Functional donors (operation-targeted).** For each determinate-negation "missing thing" from 4.3, recruit one domain that takes that operation or capacity *seriously on its own terms*. If Monk A's failure reveals a missing capacity for "repair-in-place," recruit a domain where that is central (wound healing, software hot-patching, coral-reef recovery). This is the snowmobile logic — donors chosen for the function they contribute. (The old "epistemological diversity check" is one special case: recruiting a domain that takes a resists-analysis claim seriously.)
+
+**Pool size:** the N monks **+ ~3–5 donors**, weighted toward functional donors with 1–2 random donors for anti-habit novelty. Each donor is a first-class domain entering 4.6's decomposition at the **same depth as the monk positions** — not a 2–3 paragraph isomorphism garnish. List the donors in the 4.6 domain manifest. The actual isomorphism-finding moves to 4.6 step 3, where donors are already decomposed as peers.
+
+**Why this works:** Boyd's cross-domain step made mandatory *and* multi-domain. Domain distance correlates with novelty; functional targeting correlates with relevance — you want both. Within-domain recombination cannot produce new vocabulary; a deep, functionally-targeted sea can.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "Donor Recruitment\|Functional donors\|Pool size" reference/phase4-determinate-negation.md`
+Expected: three matches. Then run `grep -n "force isomorphisms" reference/phase4-determinate-negation.md` — expected: NO match (the forcing moved to 4.6 step 3).
+
+- [ ] **Step 3: Commit**
+
+```bash
+sleep 0.01 && git add reference/phase4-determinate-negation.md && sleep 0.01 && git commit -m "Rework 4.5b into multi-domain donor recruitment (Boyd #1)"
+```
+
+---
+
+### Task 2: Add Heisenberg observer-perturbs check at 4.6 opening (#2a)
+
+**Files:**
+- Modify: `reference/phase4-determinate-negation.md` (top of `## 4.6 Boydian Decomposition`, ~line 121)
+
+- [ ] **Step 1: Insert the check**
+
+Find the paragraph beginning `**Now shatter both positions — AND the lateral material from 4.5 — into their atomic parts.**` and insert immediately AFTER it (before the numbered list `1. **Identify the generic space**`):
+
+```markdown
+**Heisenberg check (observer perturbs observed).** The act of analysis bends the positions toward synthesis — you start reading each monk as already half-reconciled with the other. Before shattering, verify you are decomposing what each monk *actually committed to* (its testimony in the essay), not a pre-smoothed version your analysis has nudged toward the middle. This is Boyd's second pillar made operational: observation disturbs the observed.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "Heisenberg check (observer perturbs observed)" reference/phase4-determinate-negation.md`
+Expected: one match, located between the "Now shatter" paragraph and "Identify the generic space".
+
+- [ ] **Step 3: Commit**
+
+```bash
+sleep 0.01 && git add reference/phase4-determinate-negation.md && sleep 0.01 && git commit -m "Operationalize Heisenberg observer-perturbs check in 4.6 (Boyd #2a)"
+```
+
+---
+
+### Task 3: Rewrite 4.6 step 2 — manifest + calibration + anti-tidiness (#1, #7, #4)
+
+**Files:**
+- Modify: `reference/phase4-determinate-negation.md` (`## 4.6` numbered step 2, ~line 125)
+
+- [ ] **Step 1: Replace step 2**
+
+Replace the current step `2. **List the atomic components** ...` (the single paragraph ending `This is Boyd's "sea of anarchy."`) with:
+
+```markdown
+2. **Construct the sea of anarchy.** First write a **domain manifest** — an explicit list of every domain in the pool as peers: `[Monk A, Monk B, (Monk C…), donor1, donor2, donor3…]` (donors recruited in 4.5b). Every entry on the manifest gets decomposed to the **same depth** — this is the guard against the monk-primary habit of shattering the essays thoroughly and skimming the donors. Then **list the atomic components** of every domain on the manifest — claims, mechanisms, evidence, assumptions, metaphors, principles, operations — stripped of which monk or donor said them.
+
+   **Tag each part with a calibration estimate.** Independent of how confidently the monk asserted it: is this part well-supported (cite-backable, mechanistically sound) or a rhetorical reach? Mark each `[solid]` / `[plausible]` / `[reach]`. The monks argue at full conviction by design; calibration is *per-part*, and the synthesis weights by it (Phase 5), not by rhetorical force.
+
+   **Anti-tidiness check (genuine destruction).** The result must be a genuinely *unstructured* collection — Boyd's "sea of anarchy." If your parts already sit in neat thematic groups, or are organized by which domain they came from, you have smuggled in a structure and the destructive step has failed. A clean taxonomy is itself an imported frame. Scramble it: provenance forgotten, no pre-categorization.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "domain manifest\|calibration estimate\|Anti-tidiness check" reference/phase4-determinate-negation.md`
+Expected: three matches, all inside the 4.6 numbered list.
+
+- [ ] **Step 3: Commit**
+
+```bash
+sleep 0.01 && git add reference/phase4-determinate-negation.md && sleep 0.01 && git commit -m "4.6 step 2: domain manifest + per-part calibration + anti-tidiness (Boyd #1/#7/#4)"
+```
+
+---
+
+### Task 4: Split 4.6 step 3 into qualities/attributes/operations passes (#3)
+
+**Files:**
+- Modify: `reference/phase4-determinate-negation.md` (`## 4.6` numbered step 3, ~line 126)
+
+- [ ] **Step 1: Replace step 3**
+
+Replace the current step `3. **Find common qualities, attributes, or operations** (Boyd's exact phrase) among parts ...` with:
+
+```markdown
+3. **Find common qualities, attributes, *or operations* (Boyd's exact phrase) — as three explicit passes.** Boyd names three distinct search targets; run each, don't collapse them:
+   - **Qualities** — shared static properties (both are fragile; both self-reinforce; both decay without input).
+   - **Attributes** — shared relational or contextual features (both depend on a boundary; both presuppose an observer; both are scale-sensitive).
+   - **Operations** — shared *functions* / dynamics / what the part *does* (both propagate; both gate flow; both convert one form into another). **This is the highest-yield pass and the one most often skipped** — the snowmobile is an operations recombination (gliding + propulsion + steering), not an appearance recombination. Run it explicitly even when qualities/attributes already produced hits.
+
+   The highest-value connections are typically between donor material and monk material. This is where the isomorphism-forcing happens — the donors are already decomposed as peers (from 4.5b + the manifest), so you are connecting liberated parts, not bolting a domain on.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "three explicit passes\|highest-yield pass" reference/phase4-determinate-negation.md`
+Expected: two matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+sleep 0.01 && git add reference/phase4-determinate-negation.md && sleep 0.01 && git commit -m "4.6 step 3: split induction into qualities/attributes/operations passes (Boyd #3)"
+```
+
+---
+
+### Task 5: Fold donor concept into 4.6 steps 4–5 (#1)
+
+**Files:**
+- Modify: `reference/phase4-determinate-negation.md` (`## 4.6` numbered steps 4 and 5, ~lines 127–128)
+
+- [ ] **Step 1: Replace step 4**
+
+Replace the current step `4. **Ask: what material from adjacent domains** might connect ...` with:
+
+```markdown
+4. **Recombine — not in the same arrangement.** Build connections among the liberated parts. Boyd is explicit: the result must NOT use the parts in the same arrangement as any original domain — if you've merely reassembled one monk's structure with different vocabulary, you haven't created anything. (Donors are recruited up front in 4.5b; if the decomposition reveals a *missing* operation that no donor on the manifest covers, recruit one more functional donor now and decompose it to equal depth before proceeding.)
+```
+
+- [ ] **Step 2: Replace step 5**
+
+Replace the current step `5. **Epistemological diversity check:** ...` with:
+
+```markdown
+5. **Epistemological diversity verification.** If a monk claims something *resists* analytical/propositional treatment (love, wisdom, quality of attention, aesthetic judgment, faith, embodied knowledge), confirm the manifest includes at least one functional donor that takes that claim seriously *on its own terms* — virtue ethics, contemplative traditions, care ethics, aesthetic philosophy, phenomenology. If every donor is itself analytical, the synthesis will dissolve the higher-order claim into lower-order terms (the level-reduction failure). If missing, recruit one now and decompose it.
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -n "Recombine — not in the same arrangement\|Epistemological diversity verification" reference/phase4-determinate-negation.md`
+Expected: two matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+sleep 0.01 && git add reference/phase4-determinate-negation.md && sleep 0.01 && git commit -m "4.6 steps 4-5: fold adjacent-domain/epistemic-diversity into donor concept (Boyd #1)"
+```
+
+---
+
+### Task 6: Add 4.6.6 loss audit + surface it at the 4.9 checkpoint (#6)
+
+**Files:**
+- Modify: `reference/phase4-determinate-negation.md` (insert new `## 4.6.6` after `## 4.6.5` ends and before `## 4.7 Sublation Criteria`; edit `## 4.9` presentation block)
+
+- [ ] **Step 1: Insert the 4.6.6 section**
+
+Immediately BEFORE the line `## 4.7 Sublation Criteria`, insert:
+
+```markdown
+## 4.6.6 Loss Audit — Single-Monk High-Value Ideas
+
+The misfit register (4.6.5) captures frame-level *friction* the synthesis will leave un-resolved. This pass captures the opposite failure: high-value *content* the synthesis will smooth away. Empirically, blending multiple model outputs drops most good ideas that appeared in only *one* output — the "hidden profile" problem (Stasser & Titus): groups over-sample shared information and lose what only one member held. The palette (Phase 5) is a partial guard; this pass makes it explicit.
+
+**Procedure:**
+1. **Extract single-monk ideas.** Scan the atomic parts list (4.6 step 2) for high-value ideas — mechanisms, observations, failure modes, reframes — appearing in **only one** monk. These "spiky" ideas are most at risk of being smoothed away.
+2. **Score provenance-blind.** Rate each for "useful, non-obvious, worth keeping" *without* reference to which monk produced it. Default: dispatch 2–3 fresh blind-judge subagents (no position, no sight of any synthesis) to score the stripped ideas — this removes the single-informed-seat bias. Minimum fallback: the orchestrator scores with provenance stripped. Use the 4.6-step-2 calibration tags as a second axis: **value × calibration.**
+3. **Coverage requirement.** Each high-value idea must be either (a) carried into a Phase 5 candidate, or (b) **consciously dropped with a one-line reason** logged to `misfit_register.md`. Silent dropping is the failure this pass exists to prevent. A high-value + low-calibration idea is carried as a *flagged hypothesis* that must earn evidence (the Phase 5 reversibility-repair path), not asserted.
+
+**Boundary with the misfit register — do not conflate:**
+- Loss-audit items are *absorbable high-value content* — smoothing them away is the bug, so **recover** them. Test: "would carrying this in make the synthesis *better*?"
+- Misfit-register items are *frame-level friction* — forcing them to fit falsifies the synthesis, so **preserve** them un-resolved. Test: "would absorbing this *falsify* the synthesis?"
+
+**Write the output** to `round_N_loss_audit.md`: each single-monk idea, its value × calibration score, and its disposition (carried-to-S / carried-to-J / dropped + reason).
+
+```
+
+- [ ] **Step 2: Add a loss-audit line to the 4.9 checkpoint**
+
+In `## 4.9`, find the bullet `> - **Do the flagged misfits look right,** or am I missing a bigger one?` and insert immediately after it:
+
+```markdown
+> - **Are the recovered high-value ideas right,** and do the conscious drops look correct — or did I smooth away something that should be carried?
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -n "## 4.6.6\|Loss Audit\|recovered high-value ideas" reference/phase4-determinate-negation.md`
+Expected: three matches. Confirm `## 4.6.6` appears before `## 4.7`: `grep -n "## 4.6.6\|## 4.7" reference/phase4-determinate-negation.md` (4.6.6 line number < 4.7 line number).
+
+- [ ] **Step 4: Commit**
+
+```bash
+sleep 0.01 && git add reference/phase4-determinate-negation.md && sleep 0.01 && git commit -m "Add 4.6.6 loss audit for single-monk high-value ideas (rohit hidden-profile #6)"
+```
+
+---
+
+### Task 7: Phase 5 reversibility check → repair loop (#5)
+
+**Files:**
+- Modify: `reference/phase5-sublation.md:72` (`**Reversibility check (Boyd).**` paragraph)
+
+- [ ] **Step 1: Replace the reversibility paragraph**
+
+Replace the paragraph beginning `**Reversibility check (Boyd).** Trace each major claim ...` (the whole line 72 paragraph) with:
+
+```markdown
+**Reversibility check (Boyd) — repair, don't reject.** Trace each major claim back to specific atomic parts from the decomposition. When a claim doesn't trace back, do NOT discard the whole synthesis — Boyd's instruction is to repair: keep the parts that cohere, add new material (recruit a new donor domain or do fresh research), and re-derive. Loop up to 3 times. After that, the untraceable claim either earns its own evidence as a genuine new insight (kept, explicitly flagged as net-new) or is cut. Also run the "not the same arrangement" test: structurally, is S just one monk's architecture wearing the other's vocabulary? That fails.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "repair, don't reject\|Loop up to 3 times" reference/phase5-sublation.md`
+Expected: two matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+sleep 0.01 && git add reference/phase5-sublation.md && sleep 0.01 && git commit -m "Phase 5 reversibility: repair loop instead of pass/fail (Boyd #5)"
+```
+
+---
+
+### Task 8: Phase 5 — add precision-vs-grip + calibration-weighting standards (#2b, #7)
+
+**Files:**
+- Modify: `reference/phase5-sublation.md` (`### S internal standards`, insert after the reversibility paragraph edited in Task 7, before `**Closure property.**`)
+
+- [ ] **Step 1: Insert two new standards**
+
+Immediately AFTER the reversibility paragraph (now ending `That fails.`) and BEFORE `**Closure property.**`, insert:
+
+```markdown
+**Precision-vs-grip check (Boyd / Heisenberg).** Over-tightening S for precision and completeness loses its match to the messy reality it describes. A synthesis that feels suspiciously clean — every loose end tucked, no remainder — has usually squeezed past the resolution the evidence supports. Boyd's third pillar operationalized: if S has no residue, suspect it. Cross-check the misfit register (4.6.5) — the genuine residue should still be visible, not dissolved.
+
+**Calibration weighting.** Weight S's load-bearing claims by the per-part calibration tags from 4.6 step 2, not by how forcefully a monk asserted them. A `[reach]`-tagged part may be rhetorically central to a monk and still a weak foundation; build S's spine from `[solid]` parts and treat `[reach]` parts as flagged hypotheses, not load-bearers. This is the prompt-level analog of confidence-modulated debate — drift toward what is well-supported, not what is loudly claimed.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "Precision-vs-grip check\|Calibration weighting" reference/phase5-sublation.md`
+Expected: two matches, both between the reversibility paragraph and `**Closure property.**`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+sleep 0.01 && git add reference/phase5-sublation.md && sleep 0.01 && git commit -m "Phase 5 S standards: precision-vs-grip + calibration weighting (Boyd #2b, MAD #7)"
+```
+
+---
+
+### Task 9: SKILL.md — update Phase 4 walkthrough + tree diagram (cross-ref)
+
+**Files:**
+- Modify: `SKILL.md:69` (tree diagram 4.5/4.6 lines), `SKILL.md:117` (Phase 4 walkthrough paragraph)
+
+- [ ] **Step 1: Update the tree diagram**
+
+Replace the line:
+```
+│   ├── 4.5: Lateral creativity — compressed conflicts, random domain, metaphors
+```
+with:
+```
+│   ├── 4.5: Lateral creativity — compressed conflicts, donor recruitment (random + functional), metaphors
+```
+
+And replace the line:
+```
+│   ├── 4.6: Boydian decomposition (destructive deduction) — shatter into "sea of anarchy," find cross-domain connections (creative induction)
+```
+with:
+```
+│   ├── 4.6: Boydian decomposition — domain manifest, shatter into "sea of anarchy," qualities/attributes/operations passes, calibration tags
+│   ├── 4.6.6: Loss audit — recover high-value single-monk ideas (hidden-profile guard)
+```
+
+- [ ] **Step 2: Update the Phase 4 walkthrough paragraph (line 117)**
+
+In the paragraph starting `You perform this yourself (not a subagent).`, replace the sentence:
+```
+Lateral creativity interventions: compressed conflict generation (oxymorons), random domain injection via Wikipedia's random article API, non-propositional pause (three metaphors).
+```
+with:
+```
+Lateral creativity interventions: compressed conflict generation (oxymorons), donor recruitment for a multi-domain sea (random Wikipedia donors + functional donors targeted at each "missing thing," decomposed to equal depth via a domain manifest), non-propositional pause (three metaphors). The Boydian decomposition tags each atomic part with a calibration estimate and runs qualities/attributes/operations as three passes. A **loss audit (4.6.6)** recovers high-value ideas held by only one monk before the synthesis can smooth them away.
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -n "donor recruitment\|4.6.6: Loss audit\|loss audit (4.6.6)" SKILL.md`
+Expected: at least three matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+sleep 0.01 && git add SKILL.md && sleep 0.01 && git commit -m "SKILL.md: reflect donor recruitment, manifest, QAO passes, loss audit in Phase 4 summary"
+```
+
+---
+
+### Task 10: SKILL.md — mark all three Boyd pillars as operationalized (#2 closure)
+
+**Files:**
+- Modify: `SKILL.md:310` (Heisenberg pillar), `SKILL.md:319` (where Boyd is operationally present)
+
+- [ ] **Step 1: Append an operational note to the Heisenberg pillar**
+
+Replace the line 310 bullet:
+```
+2. **Heisenberg's Uncertainty:** When the observer's precision approaches the phenomenon's precision, uncertainty swamps the measurement. Applied: the deeper you refine a concept, the more the concept shapes what you observe — a feedback loop that generates confusion, not clarity.
+```
+with:
+```
+2. **Heisenberg's Uncertainty:** When the observer's precision approaches the phenomenon's precision, uncertainty swamps the measurement. Applied: the deeper you refine a concept, the more the concept shapes what you observe — a feedback loop that generates confusion, not clarity. *Operationalized as two checks:* the observer-perturbs-observed check at the top of 4.6 (decompose what the monk committed to, not a pre-smoothed version) and the precision-vs-grip check in Phase 5 (a synthesis with no residue has been over-refined past the evidence).
+```
+
+- [ ] **Step 2: Update "Where Boyd is operationally present" (line 319)**
+
+Replace line 319:
+```
+**Where Boyd is operationally present:** Phase 4.6 (Boydian Decomposition — the destructive deduction), Phase 5 (Sublation — the creative induction, including the reversibility check), Phase 6 (the auditor's reversibility check), and Phase 7 (Recursion — each cycle is Boyd's full Structure → Unstructure → Restructure, which is why recursive rounds often need new research from outside the original domains).
+```
+with:
+```
+**Where Boyd is operationally present:** Phase 4.5b (donor recruitment — the multi-domain sea), Phase 4.6 (Boydian Decomposition — destructive deduction via domain manifest, anti-tidiness, qualities/attributes/operations passes, per-part calibration; plus the Heisenberg observer-perturbs check), Phase 4.6.6 (loss audit — hidden-profile guard), Phase 5 (creative induction — the reversibility *repair* loop, the precision-vs-grip check, and calibration weighting), Phase 6 (the auditor's reversibility check), and Phase 7 (Recursion — each cycle is Boyd's full Structure → Unstructure → Restructure). All three pillars now have an operational home: Gödel → reversibility + new research; Heisenberg → observer-perturbs + precision-vs-grip; Second Law → the Phase 7 entropy diagnostic.
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -n "Operationalized as two checks\|All three pillars now have an operational home" SKILL.md`
+Expected: two matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+sleep 0.01 && git add SKILL.md && sleep 0.01 && git commit -m "SKILL.md: note all three Boyd pillars now operationalized (Heisenberg closure #2)"
+```
+
+---
+
+### Task 11: Final coherence pass
+
+**Files:**
+- Read-only verification across `reference/phase4-determinate-negation.md`, `reference/phase5-sublation.md`, `SKILL.md`
+
+- [ ] **Step 1: Check for dangling references**
+
+Run: `grep -rn "4.6 step 5\|epistemological diversity check\|adjacent domains\|Random Domain Injection" reference/ SKILL.md README.md`
+Expected: no stale references to the *old* names. "Epistemological diversity verification" (new) is fine; the old "check" should be gone. If README.md still says "random Wikipedia domain injection," update that phrase to "multi-domain donor recruitment (random + functional)" to match.
+
+- [ ] **Step 2: Verify calibration tag vocabulary is consistent**
+
+Run: `grep -rn "\[solid\]\|\[plausible\]\|\[reach\]\|calibration" reference/`
+Expected: the tag names `[solid]`/`[plausible]`/`[reach]` appear in 4.6 step 2 (definition), 4.6.6 (value × calibration), and Phase 5 (calibration weighting) — same three tokens everywhere, no drift (e.g. not `[strong]` in one place and `[solid]` in another).
+
+- [ ] **Step 3: Read-through**
+
+Read `reference/phase4-determinate-negation.md` sections 4.5 through 4.9 end-to-end. Confirm: 4.5b recruits donors → 4.6 manifest decomposes them as peers → step 3 finds connections → 4.6.5 misfit register → 4.6.6 loss audit → 4.7 criteria → 4.9 checkpoint surfaces both misfits and recovered ideas. The flow should read as one continuous instruction with no orphaned cross-reference.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+sleep 0.01 && git add -A && sleep 0.01 && git commit -m "Boyd overhaul: final coherence fixes" || echo "no fixes needed"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- #1 deeper sea / unified donors → Tasks 1, 3 (manifest), 5. ✓
+- #2 Heisenberg (observer-perturbs + precision-vs-grip) → Tasks 2, 8, 10. ✓
+- #3 qualities/attributes/operations → Task 4. ✓
+- #4 anti-tidiness → Task 3. ✓
+- #5 reversibility repair → Task 7. ✓
+- #6 loss audit → Task 6. ✓
+- #7 calibration tagging + weighting → Tasks 3 (tag), 8 (weight), 6 (second axis). ✓
+- Domain manifest, no renumber → Task 3 (in-place), no task renumbers sections. ✓
+- SKILL.md cross-refs → Tasks 9, 10; README → Task 11 step 1. ✓
+
+**Placeholder scan:** No "TBD"/"handle appropriately". The repair-loop bound `K` from the spec is pinned to **3** in Task 7. Calibration tag vocabulary pinned to `[solid]`/`[plausible]`/`[reach]` and checked for drift in Task 11.
+
+**Type/term consistency:** "domain manifest," "donor," "[solid]/[plausible]/[reach]," "loss audit / 4.6.6," "value × calibration" used identically across Tasks 1, 3, 4, 6, 8, 9. Section numbers unchanged (surgical). ✓

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/docs/superpowers/specs/2026-06-15-boyd-overhaul-design.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/docs/superpowers/specs/2026-06-15-boyd-overhaul-design.md
@@ -1,0 +1,85 @@
+# Boyd Overhaul — Design Spec
+
+**Date:** 2026-06-15
+**Scope:** Strengthen the dialectic skill's treatment of Boyd's *Destruction and Creation* (1976), and harden the synthesis against diversity-loss / groupthink, grounded in two external sources.
+**Approach:** Surgical, in-place edits to existing sections (4.5, 4.6, 4.6.5, 4.7 in `reference/phase4-determinate-negation.md`; the reversibility check in `reference/phase5-sublation.md`). No new top-level phases, no renumbering of existing phases. The careful lateral-before-decomposition ordering is preserved.
+
+## Motivation
+
+Three sources triangulate on the same lesson — *the enemy is conformity / diversity loss*:
+
+1. **Boyd, *Destruction and Creation* (1976).** The skill's creative engine. Audit found five fidelity gaps between the doc and the actual essay.
+2. **rohit, "LLM councils show groupthink" (strangeloopcanon, 2026).** Empirical: councils keep only ~24% of good single-model ("spiky") ideas; peer-review rounds become consensus detectors (shared ideas survive ~33% vs ~24% single). Mechanism = Stasser & Titus's *biased sampling of shared information* → the *hidden-profile problem*. Fix = a "loss-audited council" that explicitly extracts, **stores, ranks, and assesses** each solution's best ideas separately *before* writing the final answer. Magnitudes are soft (N=16, LLM-mediated judging) but the direction matches 40 years of human group research.
+3. **Zhu et al., "Demystifying Multi-Agent Debate" (Cambridge/Sheffield, arXiv 2601.19921).** Vanilla debate is a *martingale* — preserves expected correctness, doesn't systematically improve, loses to majority vote at higher cost. Two fixes: **diversity-aware initialization** (greedily maximize distinct candidates; Pass@5 ~74–79% → ~90%; +1–3% alone) and **calibrated confidence** communication (Theorem 1: turns the martingale into a strict *submartingale* → systematic drift toward correctness; combined +2.4% GSM8K). Without diversity injection, debates "collapse to initial majority." Caveat: closed-form benchmarks with a ground-truth answer; small effects; confidence trained via RL/LoRA. Only the prompt-level *intuition* transfers, not the proof.
+
+The dialectic skill is already architected against both failure modes — full-conviction **opposed** monks = maximal diversity-init; the orchestrator analyzing *above* the debate (monks never revise toward each other) = no martingale to collapse; the palette (S/J/G/F/U) = no smoothing into one normie answer; the misfit register = a partial loss audit. These edits close the remaining gaps and make the implicit defenses explicit and operational.
+
+## The seven changes
+
+### #1 — Deeper sea of anarchy (multi-domain pool, unified sourcing)
+**Where:** `4.5b` (rework) + fold in `4.6` steps 4–5.
+**Why:** Boyd's canonical example builds a snowmobile by shattering *four* domains (skis, outboard motor, handlebars, treads) and recombining across all. The current sea is two monk-positions + 1–2 skimmed Wikipedia articles — too shallow.
+**Change:**
+- Rework 4.5b from "inject a domain, force isomorphisms in 2–3 paragraphs" into **donor recruitment for the sea**, with two streams:
+  - *Random donors* — Wikipedia random-article API, as now (novelty / anti-habit; escapes the orchestrator's conceptual filters).
+  - *Functional donors* — for each determinate-negation "missing thing" from 4.3, recruit one domain that takes that **operation** seriously (the snowmobile's donors were chosen for the function each contributes).
+- Target **N monks + ~3–5 donors**, and require **each donor decomposed to the same depth as the monk positions** — full domains entering the sea, not garnish.
+- Unify the three currently-scattered domain sources — 4.5b (random), 4.6-step-4 ("adjacent domains"), 4.6-step-5 ("epistemological diversity") — into the single donor concept. The epistemological-diversity rule (recruit domains that take a resists-analysis claim seriously) becomes a *special case* of functional-donor recruitment.
+- **Domain manifest (enforcement artifact):** the first instruction of `4.6` step 2 writes a manifest listing every domain in the pool — `[Monk A, Monk B, …, donor1, donor2, …]` — as **peers**, each to be decomposed to equal depth. This makes "which domains are in the sea, all decomposed equally" an explicit checklist rather than a prose hope, guarding against the monk-primary habit (thoroughly shatter the essays, skim the donors). **No renumber:** the manifest lives inside the existing 4.6 step 2; section numbers and cross-references are untouched.
+**Notes:** the random/functional split was the first design fork, resolved as "both, unified." The pool-structure fork (manifest vs. full restructure vs. pure prose) resolved as "manifest, no renumber."
+
+### #2 — Operationalize Heisenberg (the dead pillar)
+**Where:** `4.6` opening + `reference/phase5-sublation.md` (synthesis).
+**Why:** Gödel is operational (go outside → reversibility + new research in recursion); the Second Law is operational (Phase 7 entropy diagnostic); Heisenberg has theory text and *no operational check anywhere*.
+**Change:** two named checks, framed so all three pillars now have an operational home:
+- *Observer-perturbs-observed* (4.6 open): the act of analysis bends positions toward synthesis — verify you are decomposing what the monk **actually committed to**, not a pre-smoothed version. Ties to the existing "treat monk output as testimony, not evidence."
+- *Precision-vs-grip* (Phase 5): over-tightening the synthesis for precision loses its match to reality. A suspiciously clean / complete synthesis signals you have squeezed past the resolution the evidence supports. Ties to Adorno (a completed synthesis is suspect) and the Phase 7 entropy diagnostic.
+
+### #3 — Qualities / attributes / operations as three passes
+**Where:** `4.6` step 3.
+**Why:** Boyd names three distinct search targets; the doc cites the phrase but runs it as one "find connections" move. *Operations* (function/dynamics) is the highest-yield target and the one LLMs skip in favor of static qualities — the snowmobile is an operations recombination.
+**Change:** split step 3 into three explicit passes — *qualities* (static properties), *attributes* (relational/contextual), *operations* (function / what the part does). Flag operations as highest-yield; require it actually runs rather than collapsing into qualities.
+
+### #4 — Genuine destruction (anti-tidiness check)
+**Where:** `4.6` step 2.
+**Why:** Boyd insists on a "sea of anarchy" — a disordered field with provenance forgotten. The LLM's strong bias is a tidy categorized list, which is itself an imported structure = a *failed* destructive step.
+**Change:** add a check — the atomic list must be provenance-forgotten and **not pre-categorized** by theme / position / domain. Test: "if my parts already sit in neat groups, I've smuggled in a structure — scramble it."
+
+### #5 — Reversibility as a repair loop
+**Where:** `reference/phase5-sublation.md:72` (reversibility check).
+**Why:** Boyd's actual instruction on partial reversibility failure is to *repair*, not reject: keep the parts that cohere, add new material, retry. The doc currently only flags untraceable claims.
+**Change:** convert flag → bounded repair loop. An untraceable claim does not kill the synthesis: keep coherent parts, add new material (a new donor domain or new research), retry. After K attempts the claim either earns its own evidence as a genuine new insight or is cut.
+
+### #6 — Loss-audit / spiky-idea coverage
+**Where:** new `4.6.6`, placed before `4.7` (sublation criteria).
+**Why:** rohit's hidden-profile finding. The misfit register stores and cites dropped material but does **not rank or score it by value**, and it targets *un-resolved frame friction*, not *high-value content* the synthesis would smooth away. There is also no blind, multi-judge scoring step — the orchestrator decomposes and synthesizes from a single fully-informed seat, the configuration most prone to hidden-profile loss.
+**Change:**
+- Extract every high-value idea appearing in **only one** monk (the single-monk "spiky" ideas).
+- **Score provenance-blind** — ideally a few fresh blind-judge subagents rating each idea for "useful, non-obvious, worth keeping" without knowing which monk produced it or whether the synthesis will keep it (mirrors rohit's two-blind-judge method; fixes the single-seat problem). Orchestrator-only scoring with provenance stripped is the minimum fallback.
+- **Coverage requirement:** each high-value spiky idea is either carried into S / a palette candidate, **or** consciously dropped with a one-line reason logged to the misfit register.
+
+**Boundary with the misfit register (4.6.5) — keeps #6 from contradicting it:**
+
+| | Loss-audit (#6) | Misfit register (4.6.5) |
+|---|---|---|
+| Object | high-value *content* (mechanism, observation, failure mode) | frame-level *friction* |
+| Failure mode | smoothing it away → **recover** it | forcing it to fit → **preserve** un-resolved |
+| Test | "would carrying this in make S *better*?" | "would absorbing this *falsify* S?" |
+
+### #7 — Per-claim calibration + confidence-weighted synthesis
+**Where:** `4.6` (decomposition tagging) + `reference/phase5-sublation.md` (weighting); second scoring axis in `4.6.6`.
+**Why:** Zhu et al.'s submartingale mechanism. The monks stay at uniform full conviction (the Electric Monk premise — they carry belief so the orchestrator is belief-free; unchanged). But conviction is *global*; calibration is *per-claim*. A fully-committed monk still mixes rock-solid claims with rhetorical reaches.
+**Change:**
+- When shattering positions into atomic parts (4.6), **tag each part with an independent calibration estimate** — how well-supported it is, regardless of how confidently the monk asserted it.
+- **Weight the synthesis by calibration, not rhetorical force.** This imports the submartingale mechanism into the *orchestrator's* seat without touching the monks.
+- Composes with #6 as a second scoring axis: high-value + well-calibrated → carry hard; high-value + low-calibration → carry as a *flagged hypothesis* that must earn evidence (the #5 repair path).
+
+## Cost / caveats
+- #1 (donors decomposed to depth) and #6 (blind-judge subagents) make Phase 4 heavier — rohit's own "slower and heavier" caveat. Lean on the existing Phase 4 context-management guidance (summarize essences, write full output to file) to absorb it.
+- The Cambridge proof (submartingale → correctness) assumes a ground-truth answer; the dialectic is open-ended, so only the *intuition* of #7 transfers, not the theorem. Stated as such in the doc.
+- These are markdown/instruction edits to a mature, battle-tested skill. Risk is wording that misfires at runtime, not code regressions. Validation is a careful read-through + ideally one live dialectic run comparing before/after on the determinate-negation and synthesis artifacts.
+
+## Out of scope
+- No restructure into a separately-numbered "Sea of Anarchy" construction phase with a renumber cascade (considered; rejected as too much blast radius for the gain — the enforcement it would provide is captured by the in-place domain manifest in #1).
+- No RL/training-based confidence calibration (not applicable to a prompt-level orchestration skill).
+- No changes to the README beyond reflecting the above once the reference docs land.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/docs/superpowers/specs/2026-06-16-stage-phase-docs-design.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/docs/superpowers/specs/2026-06-16-stage-phase-docs-design.md
@@ -1,0 +1,63 @@
+# Staging Phase 4 and Phase 6 Reference Docs — Design
+
+## Problem
+
+An orchestrator running a live dialectic skipped reading the full `reference/phase4-determinate-negation.md` (273 lines), reporting it as "too long" and hitting file-read problems. Phase 6 (`phase6-validation.md`, 365 lines) is even longer and exposed to the same failure.
+
+The deeper issue is not just file size — it is *when* the file is read. `SKILL.md` instructs the orchestrator to read the entire phase doc at the **start** of the phase. By the time it reaches the back-half steps (Boydian decomposition, donor primers, the per-candidate auditor prompts), the relevant instructions are far back in context and half-forgotten. Some agents now bail on the read entirely.
+
+## Solution
+
+Two-part fix:
+
+1. **Just-in-time staged reads.** Split each oversized phase doc into a short **index** file plus several **stage** files. The orchestrator reads one stage, does that stage's work, then reads the next stage — instead of pulling the whole phase up front. Reads are small, and each stage's instructions land in context exactly when that stage executes.
+
+2. **Per-stage write-out checkpoint.** Each stage file ends with an explicit instruction to write that stage's output to the round file *before* reading the next stage. This converts the existing "write as you go" guidance into a hard gate, and makes context safe to compact between stages because each stage's work is already persisted.
+
+## Constraints
+
+- **Verbatim text moves.** Existing section text is cut/pasted into stage files unchanged. The wording was tuned over multiple field-test runs; this effort restructures, it does not reword. The only *new* prose is the index framing wrappers and the per-stage write-out footers.
+- **No renumbering.** Section numbers (4.0, 4.5b, 4.6.5, 6.2.S, …) stay stable so every internal cross-reference (e.g., 4.2.5's "see 4.6.5 for format") still resolves across files.
+- **Inline execution.** This is documentation restructuring with no code and no tests, so it is executed inline rather than via subagent TDD loops.
+
+## Phase 4 → index + 4 stages
+
+`reference/phase4-determinate-negation.md` becomes the **index**: cross-cutting framing that applies throughout the phase (N-monk scaling block, context-management note, treat-monk-output-as-testimony, write-your-initial-guess-first), plus a stage map and the staging + write-out protocol.
+
+| File | Sections | Cognitive move |
+|---|---|---|
+| `reference/phase4-stage-a-analysis.md` | 4.0–4.4 | Find the collision |
+| `reference/phase4-stage-b-lateral.md` | 4.5a / 4.5b / 4.5c | Build the sea (donor pipeline) |
+| `reference/phase4-stage-c-decomposition.md` | 4.6, 4.6.5, 4.6.6 | Shatter, recombine, instrument |
+| `reference/phase4-stage-d-criteria.md` | 4.7, 4.9 | Sublation criteria + HARD STOP checkpoint |
+
+## Phase 6 → index + 3 stages
+
+Phase 6's setup steps (6.0 select candidates, 6.1 model selection) run once up front, so they live in the index rather than a stage of their own. The three working stages repeat per candidate under validation.
+
+| File | Sections | Move |
+|---|---|---|
+| `reference/phase6-validation.md` (index) | header framing + 6.0 + 6.1 + stage map | Setup |
+| `reference/phase6-stage-a-monk-validation.md` | 6.2 (S/J/G/F/U prompts) | Monks validate |
+| `reference/phase6-stage-b-hostile-auditor.md` | 6.3 (S/J/G/F/U prompts) | Auditor attacks |
+| `reference/phase6-stage-c-interpret-refine.md` | 6.4, 6.5, 6.6 | Interpret + refine |
+
+## SKILL.md changes
+
+The two lines:
+- `**Read `reference/phase4-determinate-negation.md` before executing.**`
+- `**Read `reference/phase6-validation.md` before executing.**`
+
+each gain a clause noting the doc is **staged**: read the index first, then read each stage file just-in-time as you reach it (and write the stage's output before reading the next). The phase walkthrough prose is otherwise unchanged.
+
+## Index file protocol (shared shape)
+
+Each index ends with a short protocol block, roughly:
+
+> **This phase is staged. Read one stage file at a time, in order — not all at once.** For each stage: read the stage file, do its work, **write that stage's output to `round_N_*.md`**, then read the next stage. The framing above applies to every stage. Section numbers are continuous across the stage files, so cross-references (e.g. "see 4.6.5") point to whichever stage holds that section.
+
+## Out of scope
+
+- Rewording or compressing any existing section text.
+- Phases 1, 2, 3, 5, 7 (all comfortably sized).
+- Changing the dialectic's logic, prompts, or section ordering.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/misfit-patterns-watchlist.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/misfit-patterns-watchlist.md
@@ -1,0 +1,63 @@
+# Misfit Patterns Watchlist
+
+This file accumulates cross-dialectic structural patterns seen in the misfit register (Phase 4.2.5 and 4.6.5). Patterns are promoted here when the same *shape* of misfit has surfaced in 3+ independent dialectics.
+
+**How to use this file:** At 4.2.5 and 4.6.5, skim this list. If one of these patterns applies to the current dialectic, note it explicitly in the register — convergent evidence across independent domains is itself a structural finding. Don't force-fit. If the pattern's shape genuinely doesn't apply, move on.
+
+**How patterns get added:** After a cross-dialectic review (typically once ~5 dialectics have accumulated misfit registers), shapes that appear in 3+ independent runs get named and added here with their observed instances. Remove patterns if they stop reappearing across subsequent runs.
+
+---
+
+## Pattern 1: Named-author primacy — "Both positions need the authoring agent to remain the load-bearing variable"
+
+**Shape:** Both Monks share a disguised interest in some named human or small adjudicating set remaining the relevant causal variable — framework author's taste, small set of causal mechanisms, the designer, the organizing intelligence. Neither position can survive in a world where the substrate (tooling, emergent systems, collective practice) makes that authored judgment fungible.
+
+**Observed instances:**
+- `garden-design R1`: both need the designer to author the garden's coherence, not the family's lived ritual practice
+- `european-miracle R1`: both need causation adjudicable by a small causal set their methods can handle, not high-dimensional emergence
+- `react-vue R1`: both need the framework author's taste to remain the relevant variable, not compilers/standards/AI
+
+**Why it matters:** This pattern names a *frame-level* structural feature that is invisible within any single dialectic. Its presence is a signal that the dialectic is operating inside a human-authorship frame that the actual phenomenon may be leaving behind.
+
+**What to do if it applies:** Note the specific authoring agent both positions are protecting, and the specific decentralizing reality both positions need to deny. Do not try to resolve it in the synthesis — note it and let it enter the register.
+
+---
+
+## Pattern 2: Bounded-explanandum — "Both need the object of debate to be bounded and explicable by a single organizing principle"
+
+**Shape:** Both positions need the thing being debated to be a coherent bounded object with a single organizing principle. The possibility that the object is a loose coalition / high-dimensional emergent / multiply-constituted is allergically avoided. Usually co-occurs with Pattern 1 — boundedness is what keeps named-author primacy legible.
+
+**Observed instances:**
+- `garden-design R1`: both need the yard to be one coherent design-object
+- `european-miracle R1`: both need "the Industrial Revolution" to be a bounded event with clear before/after
+- `react-vue R1`: both need "paradigm" to be a well-defined category and the React/Vue binary to be the correct unit
+
+**What to do if it applies:** Ask what a loose-coalition / multiply-constituted version of the object would look like. Often the answer is the real hidden question.
+
+---
+
+## Pattern 3: Framing serves discourse-producers — "The binary serves the producers of the discourse, not the actual decision-makers"
+
+**Shape (Lens C, Foucault):** The current binary is a fossil of an earlier professional conflict in an adjacent field. It persists not because it illuminates the actual choice being made but because specific constituencies — magazines, disciplinary specialists, tech media, policy advocacy networks — have stakes in the debate remaining stateable in these terms.
+
+**Observed instances:**
+- `garden-design R1`: rooms-vs-flow is a fossil of 20thC anglophone landscape-design discourse (Jekyll/Lutyens vs. Oehme/van Sweden) serving designers and magazines
+- `european-miracle R1`: deep-vs-contingent is Weber/Marx reformatted through Cold War modernization theory, serving disciplinary specialization
+- `react-vue R1`: corporate-lab-vs-auteur is a fossil of the 2014-2018 Angular 1→2 trauma, serving legacy community identities and tech media
+
+**What to do if it applies:** Name the constituency whose interest is served by the framing persisting. Note that the actual decision-makers (this family, a developer choosing a framework today, a historian trying to explain an outcome) may face a different-shaped decision entirely.
+
+---
+
+## Pattern 4: Third-way literature already exists — "A live case/literature that dissolves the binary is in the briefing and both sides ignore it"
+
+**Shape (Lens A, briefing residue):** The Phase 1 briefing contains reference to existing work, cases, or frameworks that already offer a third way — a multicausal consensus, an alternative typology, an exemplar that can't be categorized by either Monk. Both positions walk past it, because engaging would collapse the binary they need.
+
+**Observed instances:**
+- `garden-design R1`: Localscapes methodology already in play; existing fruit trees already planted
+- `european-miracle R1`: Koyama/Rubin (2022) multicausal consensus; Goldstone "efflorescences" as test bed
+- `react-vue R1`: Eghbal's four-cell Stadium/Federation/Club/Toy typology; Vercel-NuxtLabs acquisition as crux test
+
+**What to do if it applies:** Name the specific third-way material from the briefing. This is an explicit input the monks chose not to metabolize — that choice is itself the misfit, not the material being overlooked.
+
+**Related upstream action:** Phase 1 (1c/1d) now explicitly probes for this — "what does the existing literature propose as a third way that neither pole represents?" — so the briefing surfaces it before the monks get written. When this pattern appears at 4.6.5, it means the monks walked past briefing material that was specifically placed to challenge them.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase1-elenctic-interview.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase1-elenctic-interview.md
@@ -1,0 +1,160 @@
+# Phase 1: Elenctic Interview + Research
+
+This is the most important phase. Everything downstream depends on it.
+
+## 1a. Explain the Process to the User
+
+**Before anything else, tell the user what's about to happen and why.** Many users have never encountered a structured dialectical process. If they don't understand the shape of what's coming, they'll be passive consumers of output instead of active co-pilots — and the process needs them as co-pilots. Deliver something like:
+
+> Here's how this works. We're going to use a structured process to dig into this topic and build a deeper understanding than either of us could reach alone.
+>
+> **Step 1: Interview.** I'm going to ask you a bunch of questions. Not to quiz you — to understand what you're really wrestling with underneath the surface framing. The better I understand your situation, the better everything downstream works.
+>
+> **Step 2: Research.** I'll do deep research on the topic [or: I'll build a detailed picture of your situation from what you tell me] so I'm genuinely knowledgeable about the landscape.
+>
+> **Step 3: Two "Electric Monks."** I'll create two AI agents, each of which will *fully believe* one side of the tension you're facing. They won't hedge or try to be balanced — they'll each make the absolute strongest case for their position. The reason: when you read two positions argued at full conviction, you can see the *structure* of the disagreement clearly, without having to hold either position yourself.
+>
+> **Step 4: Structural analysis and synthesis.** I'll analyze *how* each position fails, find the deeper question underneath, and build a synthesis that transforms the question itself — not a compromise, but something genuinely new that neither side could have seen alone.
+>
+> **Step 5: We keep going.** Each synthesis generates new tensions. We'll do multiple rounds, and each round gets sharper and more insightful as we dig deeper into the heart of the matter. The first round is the least calibrated — think of it as setting the stage. The real breakthroughs usually come in rounds 2 and 3.
+>
+> **The most important thing: YOU are the source of the best insights here.** I'll get things wrong. The monks will make bad assumptions. The synthesis might miss something obvious to you. **Interrupt me constantly.** Correct wrong assumptions. Throw in new ideas when they occur to you. Tell me "that's not quite right, it's more like..." The value of this process comes from the collision between the structured analysis and your actual knowledge and judgment. Don't trust the output — interrogate it.
+
+Adapt the language to the user — this is a template, not a script. For technical users, you can be more concise. For users unfamiliar with AI tools or structured analysis, spend more time on the explanation.
+
+## 1b. Understand What the User Wants
+
+Ask the user what they're thinking about. Determine:
+
+- **Mode A (Stress-Test):** User has one idea they want to challenge. You need to identify the strongest possible antithesis.
+- **Mode B (Opposition):** User has two positions in tension. You need to refine both to their steelman forms.
+
+**Default monk count is 2.** Binary contradiction is the core structural unit of the dialectic and produces the tightest analysis. But 2 monks sometimes leaves a valid big perspective on the table — a position that can't be reached as a blend of the two poles, or that's arguing on a different axis entirely. If the interview surfaces such a position, add a third (or fourth) monk. See 1c.1.
+
+## 1c. Elenctic Probing
+
+Interview the user using Socratic technique. Your goal is to surface:
+- Hidden assumptions they haven't articulated
+- The *deepest* version of the contradiction (not the obvious surface-level framing)
+- What domain type this is (empirical, normative, personal, creative — this affects what a good synthesis looks like)
+- What specific parameters of their mental model they want updated
+
+Key questions to probe:
+- "What's your strongest intuition here? Where does it break down?"
+- "What would change your mind?"
+- "What are you actually optimizing for?"
+- "What's the version of the opposing view that worries you most?"
+- "Is this a decision you need to make, or understanding you want to build?"
+- **"What does the existing literature/practice propose as a third way that neither pole represents?"** — in test runs, the misfit register's briefing-residue lens consistently finds that a live third-way case or framework already exists in the domain (e.g., Koyama/Rubin multicausal consensus, Eghbal's four-cell typology) and both monks walk past it. Surfacing it during the interview lets the briefing include it so the monks have to engage rather than ignore.
+
+## 1c.1 Third-Pole Probe (Missing-Perspective Check)
+
+**Default is 2 monks.** Before closing the interview, run one explicit probe for a missing third pole. 2-monk framings most often leak perspective when a live position exists that's arguing on a genuinely different axis than A↔B — and that position tends to be invisible from within either of the two poles.
+
+Ask the user (or ask yourself if the user won't have the meta-view):
+
+> Is there a live position here that isn't reachable as a blend of A and B — one that's arguing on a different axis entirely, or that starts from a premise neither A nor B shares?
+
+A **third (or Nth) monk is warranted when** all three of these hold:
+
+1. **Not a blend.** The candidate position cannot be reached by any A↔B slider. If it sits on the same axis as A and B, it's a midpoint, not a new monk — skip it.
+2. **Independent constituency or literature.** It has its own defenders, tradition, named thinkers, or a coherent practitioner community. A position with no constituency is usually a confabulation or the orchestrator's own view smuggled in.
+3. **Orthogonal axis, ideally.** The strongest third monk argues on a different axis entirely (e.g., A/B debate *what method works best*, C argues *method choice is downstream of relational factor X*). Orthogonal-axis monks are where 2-monk framings most often leak the big perspective Kyle's experience flagged.
+
+**Cap practically at 4 monks.** Beyond that, user attention can't hold the output, decorrelation degrades (the Nth monk starts shading into earlier monks), and Phase 4's pairwise structural analysis gets unwieldy.
+
+If you add a third (or fourth) monk, name each explicitly — don't just number them. "Monk C: the Schumacherian ground-condition position" is legible; "Monk 3" isn't. The name anchors what the monk must believe and keeps Phase 4's pairwise determinate negations from blurring into each other.
+
+If no third pole surfaces that meets all three criteria, run with 2 monks — and note in the briefing that the third-pole probe was run and came up empty. This closes the loop; later phases (especially the misfit register) can check whether a position the probe missed surfaces in the monks' essays.
+
+**Anti-sycophancy warning:** The elenctic interview is where position-tracking starts. The user will share what they think, what they've read, what frameworks they find compelling. Your job is to understand the *shape of the tension* — not to figure out which side the user leans toward so you can build the synthesis in that direction. If the user seems excited about a particular framework or thinker, that's useful information for grounding the monks, but it is NOT a signal about where the synthesis should land. The user came to this tool to be in the belief-free seat. Help them get there — don't track their position and feed it back to them as a synthesis.
+
+## 1d. Ground the Monks (Domain-Adaptive)
+
+The monks need deep grounding before they can believe effectively. But *what* constitutes grounding depends on the domain type and how novel it is. The skill must adapt.
+
+**Research depth is the main knob.** It's the only phase that meaningfully changes the time and cost profile — everything else (essays, analysis, synthesis, validation, auditor) is fast regardless. Calibrate research investment based on how much the orchestrator already knows:
+
+- **Novel/obscure domain** (emerging technology, niche policy, unfamiliar institution): Full parallel research — 2-3 agents, 150-250K tokens. The orchestrator's training data is thin or outdated. You need the research to write good framing corrections, identify degenerate framings (the obvious, shallow version of the dialectic that won't produce insight — e.g., "libraries vs frameworks" when the real tension is about incentive alignment), and ground the briefing in specifics. This is the case where research is the highest-value spend.
+- **Well-known domain** (React vs Vue, microservices vs monolith, common career decisions): Skip or minimize research. The orchestrator's training data is rich. Write the briefing from your own knowledge, perhaps with 2-3 targeted searches to check for recent developments. Save 10-20 minutes and 150K+ tokens.
+- **Known domain, novel angle** (React vs Vue but specifically "how does OSS funding structure causally shape innovation character?"): Light research — a few targeted searches on the specific angle, not broad domain surveys. The orchestrator knows the landscape but needs to check the specific thesis.
+
+**Don't default to full research out of caution.** If you can already write strong framing corrections and identify the degenerate framing without searching, you know enough. Unnecessary research doesn't just waste tokens — it wastes the user's time, which is the scarcest resource.
+
+### External-Research Domains (engineering, strategy, policy, technical architecture)
+
+These domains have literature, case studies, data, and named thinkers. The grounding comes from outside the user.
+
+**When full research is needed,** run 2-3 parallel research subagents on different aspects of the domain. A natural split that works well:
+1. **Side A's strongest literature** — the key thinkers, evidence, and arguments for one position
+2. **Side B's strongest literature** — same for the other side
+3. **Broader landscape/context** — institutional structures, historical parallels, adjacent domains, empirical data
+
+The landscape agent consistently takes longest (broadest scope) — give it more specific targeting to avoid scope creep. Instead of "research the OSS funding landscape," say "research 5-7 specific OSS companies' GTM trajectories, focusing on the transition from developer adoption to enterprise revenue."
+
+This is expensive (~150-250K tokens across agents) but is the single most valuable investment in the entire process — deep grounding is what makes everything downstream good.
+
+Research agents should be given *specific* search targets — not "research this topic" but "search for X's argument about Y, specifically the part about Z."
+
+### Personal and Values Domains (life decisions, career, relationships, commitments, priorities)
+
+These domains have little useful external literature. The grounding comes from *the user themselves* — their history, values, constraints, relationships, and patterns. **The interview IS the research.**
+
+The elenctic probing (1c) must go deeper and wider for these domains. You need to map:
+
+- **The full landscape of commitments.** Not just the two in tension — *everything* the user is carrying. Ask: "Walk me through what's on your plate right now — all of it." Undifferentiated care (the Empathic Integrator pattern) only becomes visible when you see the full load.
+- **The history.** "Have you faced a decision like this before? What happened? What did you choose? How did it feel afterward?" The Exploratory Debater's commitment pattern only becomes visible across multiple instances. The Practical Executor's optimization lock only shows when you see what they *haven't* questioned.
+- **The stakeholders and their actual capacities.** "Who else is affected by this? What can they actually do — not ideally, but right now?" This separates the vision from the reality, which is the Empathic Integrator's core split.
+- **The values underneath the positions.** "You say you value X and also Y. If you could only have one — gun to your head — which?" This surfaces the Possibility Explorer's values hierarchy that they resist articulating.
+- **The constraints they're treating as fixed.** "What would you do if [constraint] disappeared tomorrow?" This reveals which constraints are real and which are assumed.
+
+**Spend 6-10 exchanges on this.** For personal domains, the interview should be roughly twice as long as for external-research domains. You're building the equivalent of the context briefing from the user's own testimony.
+
+**Limited external research may still help.** Search for frameworks, not facts: "how do people navigate career transitions at [user's life stage]," "decision frameworks for competing values," "what does research say about [specific situation type]." This gives the monks structural scaffolding, not positions to believe — the positions come from the user's own material.
+
+### Mixed Domains (normative/institutional, creative direction)
+
+These need both. A dialectic about institutional identity, for example, requires external research (organizational history, governance structures, comparable institutions) *and* the user's personal values and judgment about what the institution should become. The interview needs to surface the personal dimension while the research agents cover the external.
+
+For mixed domains, run the extended interview *and* the research agents, and note in the briefing document which material is user-sourced (values, priorities, constraints) vs. externally-sourced (evidence, history, precedent). The monks need to know the difference — they should believe positions grounded in the user's actual situation, not generic arguments.
+
+### In All Cases
+
+You need to know the domain well enough to:
+- Identify and correct likely **degenerate framings** (the obvious/boring version of the dialectic that won't produce insight)
+- Generate **specific research directives or interview questions** for each subagent
+- Write **framing corrections** that steer monks away from shallow takes
+- Identify the **deepest available contradiction**
+
+## 1e. Write the Context Briefing Document
+
+**Synthesize everything — external research AND user-sourced material — into a single neutral briefing document and save it to a file** (e.g., `round_1_context_briefing.md`). Write the full briefing to the file — present only a concise summary to the user at the confirmation step (1f).
+
+For **external-research domains**, this covers:
+- Key evidence, sources, and arguments from all sides
+- The landscape of the debate — who the key thinkers are, what positions exist
+- Relevant empirical data, historical context, institutional structures
+- The specific framing you've identified as the deepest contradiction
+
+For **personal/values domains**, this covers:
+- The user's full commitment landscape (all the things they're carrying)
+- Relevant history and patterns (past decisions, outcomes, recurring themes)
+- Stakeholders and their actual capacities
+- The values hierarchy as best you can reconstruct it
+- Constraints (which are real, which are assumed)
+- The specific tension you've identified as the deepest contradiction
+
+For **mixed domains**, both sections.
+
+Both monks will read this file before writing. For personal domains this is especially important — it gives the monks the user's actual situation rather than letting them argue from generic positions. A monk that believes "you should prioritize your career" in the abstract is useless. A monk that believes "given your specific history of X, your constraint of Y, and the fact that stakeholder Z can actually handle Q — you should prioritize your career *because*..." is an Electric Monk doing its job.
+
+## 1f. Confirm with the User
+
+Before proceeding, summarize back:
+- "Here's how I understand the two positions..."
+- "Here's what I think the real tension is..."
+- "Here's what I'll have each agent research and argue..."
+- **"Are there companies, thinkers, comparison classes, or evidence we're missing?"** — This question consistently produces the highest-leverage interventions in the entire process. In testing, users caught missing competitors (Vercel's agentic play), missing comparison classes (AI-native devtools), and missing authority structures that fundamentally changed the synthesis.
+- **"Is there a third live position we're not accounting for — one that isn't a blend of A and B, or that's arguing on a different axis entirely?"** — This is the third-pole check from 1c.1 surfaced one more time before the briefing locks. If the user names a position that meets the three criteria (not-a-blend, independent constituency, ideally orthogonal axis), add it as Monk C and update the briefing.
+
+Get the user's confirmation or correction. If the user identifies gaps, run a supplementary research agent to fill them and update the briefing before proceeding. **State the final monk count and what each monk will believe** before moving to Phase 2 — this prevents the orchestrator from silently dropping or adding monks later.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase2-monk-prompts.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase2-monk-prompts.md
@@ -1,0 +1,73 @@
+# Phase 2: Generate the Electric Monk Prompts
+
+Generate one prompt per Electric Monk — **typically 2, sometimes 3 or 4** if Phase 1c.1 surfaced a third (or fourth) pole meeting the criteria. Each monk must *believe* its position at full conviction. This is not roleplay or debate — it is the functional core of the artificial belief system. A hedging monk is an Electric Monk that has failed at its one job: if the monk doesn't fully believe, the user has to carry part of the belief load, which means they can't occupy the belief-free orchestrator position where the real thinking happens.
+
+Calibrate the monks based on what you learned in Phase 1c':
+- **What must each monk believe?** (Shaped by the user's belief burden)
+- **What must Monk A validate?** (Always validate the user's dominant mode first)
+- **What must each other monk hold that the user can't natively hold?**
+
+**N-monk note.** When there are 3+ monks, each monk's framing corrections must preempt degenerate framings against *every other monk*, not just one opponent. A Monk C that only argues against A will silently treat B as an ally; the result is a 2-vs-1 argument, not genuine three-way decorrelation. Each monk should know what it believes *and* what it specifically rejects about each other pole.
+
+## Required Prompt Structure
+
+```
+1. ROLE: "You are an Electric Monk — your job is to BELIEVE [POSITION] with
+   full conviction, carrying this belief on behalf of a human who needs to
+   analyze it from outside. You genuinely believe [EACH OTHER POSITION, NAMED] is wrong — for different specific reasons per position.
+   Make the strongest possible case — not a balanced comparison, but a committed
+   philosophical and technical argument from deep inside this belief.
+
+   You are not arguing FOR this position — you ARE this position. Inhabit it
+   fully. Ask yourself: what would the world look like if I had spent my career
+   developing this framework? What problems would I see everywhere? What would
+   I find obvious that others miss? What would frustrate me about how others
+   think about this?"
+
+2. FRAMING CORRECTIONS: Preempt degenerate framings.
+   "Important: your argument is NOT [OBVIOUS WEAK VERSION]. Both sides [SHARED
+   QUALITY]. The real difference lies in [DEEPER TENSION]."
+
+3. CONTEXT BRIEFING: "Read the context briefing at [PATH TO context_briefing.md].
+   This contains comprehensive research and/or the user's own situation, values,
+   and constraints. Use it as your primary evidence base. Believe FROM this
+   material — ground your conviction in specifics, not generics."
+
+4. ADDITIONAL RESEARCH DIRECTIVES: 2-3 targeted searches for position-specific
+   evidence the briefing doesn't cover.
+   "After reading the briefing, do these additional targeted searches:
+    1. Search for [EVIDENCE SPECIFIC TO THIS AGENT'S POSITION]
+    2. Search for [STRONGEST VERSION OF THIS SIDE'S ARGUMENT]
+    3. Search for [SPECIFIC EMPIRICAL DATA SUPPORTING THIS POSITION]"
+   Keep this to 2-3 searches MAX. The briefing already covers the broad landscape.
+
+5. ARGUMENT STRUCTURE:
+   a. Ontological claim: What IS the thing we're arguing about? What is its
+      proper nature/purpose/structure?
+   b. Opponent's strongest case: State your opponent's best argument in terms
+      THEY would endorse. Prove you understand what you're destroying. This
+      is NOT a concession — it's target acquisition. Do NOT say "they make a
+      compelling point." DO say "their strongest claim is X. Here is why X
+      fails at the structural level..."
+   c. Diagnosis of the other side's failure: Specific, not dismissive. Not
+      "they're wrong" but "they fail BECAUSE of THIS, which reveals THAT."
+   d. The deeper principle at stake
+   e. Push to the extreme: "State the strongest, most uncomfortable version
+      of your thesis. If your logic leads somewhere provocative, go there.
+      Commit fully."
+   f. Show your reasoning skeleton: "Make your inferential chain explicit —
+      your starting premises, the key steps, and where your position is
+      structurally load-bearing (i.e., if THIS claim fell, the whole
+      argument collapses). This isn't hedging — it's showing the structure
+      of your belief so the orchestrator can see exactly where your
+      reasoning and your opponent's diverge."
+
+6. ANTI-HEDGING: "You are an Electric Monk. Your ONE JOB is to believe this
+   position fully so a human doesn't have to. If you hedge, the human has to
+   pick up the belief weight you dropped — and that defeats the entire purpose.
+   Do NOT be balanced. Do NOT acknowledge the other side's merits. BELIEVE."
+
+7. LENGTH: 1500-2000 words for Round 1, 1000-1500 words for recursive rounds.
+```
+
+**Why full belief is non-negotiable:** This is an artificial belief system, not a debate exercise. The user's cognitive agility depends on the monks carrying 100% of the belief load. When both monks believe fully, the user can operate in the belief-free space between them — analyzing the *structure* of the contradiction, spotting shared assumptions, finding cross-domain connections. When a monk hedges ("both sides have merit"), the user is pulled back into belief-space, their transients slow, and the dialectic degrades into a book report.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase3-spawn-monks.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase3-spawn-monks.md
@@ -1,0 +1,54 @@
+# Phase 3: Spawn the Electric Monks
+
+Spawn each monk as a separate subagent session — **typically Monk A and B, sometimes also C or D** if Phase 1c.1 surfaced additional poles. Use `claude -p` (or your environment's equivalent for spawning an independent agent) so each gets a clean context with full belief commitment.
+
+```bash
+# Example for Claude Code (scales to N monks):
+echo "[MONK A PROMPT]" | claude -p --allowedTools web_search,web_fetch,read_file > round_1_monk_a.md
+echo "[MONK B PROMPT]" | claude -p --allowedTools web_search,web_fetch,read_file > round_1_monk_b.md
+# If third-pole probe added a Monk C:
+echo "[MONK C PROMPT]" | claude -p --allowedTools web_search,web_fetch,read_file > round_1_monk_c.md
+```
+
+Run all monks in parallel if your environment supports it.
+
+**Efficiency note:** With the context briefing in place, monks need only 2-3 targeted searches each (vs. 15-25 without it). For personal/values domains, monks may need zero additional searches — the briefing contains the user's own material which is the primary evidence base.
+
+**For recursive rounds (Phase 7):** See Phase 7 for guidance — recursive rounds may or may not need new research depending on whether the new contradiction opens new conceptual domains.
+
+**After both complete:** Read both outputs carefully. Check:
+- Did each monk actually *believe* fully, or did it hedge? (A hedging monk has failed its core function.)
+- Did the framing corrections work, or did a monk fall into the degenerate framing?
+- Are the arguments grounded in specific evidence (from the briefing or their own searches)?
+
+**Decorrelation check:** Verify the monks actually diverged. The skill's value comes from *structurally uncorrelated* exploration of the problem space. Check pairwise across all monks:
+- Do the monks cite *different* evidence, or substantially overlapping sources?
+- Do they frame the problem using *different* conceptual vocabularies?
+- Do their unstated assumptions *diverge*, or do they share the same background framework?
+- Would a reader recognize these as genuinely *different perspectives,* or the same perspective with different conclusions bolted on?
+
+**With 3+ monks, check for coalition collapse.** The failure mode is two monks sharing a frame while only the third is genuinely different — this is a 2-vs-1 argument masquerading as three-way dialectic. If C is clearly orthogonal but A and B have collapsed onto the same axis, the third-pole probe worked but the A/B decorrelation didn't; reformulate A or B before proceeding. If any two monks' framings blur into each other, cut to 2 monks rather than ship degraded decorrelation.
+
+If decorrelation is low — the monks are in "same framework, different conclusions" mode — consider reformulating the belief burdens to force genuinely different conceptual frames, not just different positions within one frame.
+
+**If a monk's output hedges or is off-base:** Prefer restarting with a revised prompt over nudging. Fresh context with better instructions produces better results than correcting a monk that's lost its conviction.
+
+**Save each monk's essay to a file** (e.g., `round_1_monk_a.md`, `round_1_monk_b.md`, `round_1_monk_c.md`). **Present a structural summary to the user** — not the essays themselves. The essays are raw material for the orchestrator's decomposition; most users won't read them and shouldn't need to. Give the user a quick orientation instead (scale to N monks):
+
+> The monks have written their essays (saved to files if you want to read them). Here's the structural summary:
+>
+> **Monk A** argued [2-3 sentence summary of the core claim, key evidence, and most interesting move].
+>
+> **Monk B** argued [2-3 sentence summary of the core claim, key evidence, and most interesting move].
+>
+> [**Monk C**, if present, argued ...]
+>
+> **Where they diverged:** [describe the structural differences pairwise — what conceptual frame each used. With 3+ monks, note which pair diverged most and which least — the pair that diverged least is a decorrelation risk].
+>
+> **Anything surprising:** [Note if a monk made an unexpected move, cited evidence you didn't anticipate, or took the position somewhere the user might not have expected].
+
+Then ask:
+1. Does this capture the positions accurately, or is either monk missing something important about how this actually works?
+2. **"Is there a claim either monk makes that should be tested against evidence neither has considered?"** — This is the second high-leverage intervention point. In testing, users identified claims that sounded plausible but collapsed under scrutiny when tested against comparison classes the monks didn't consider. Catching this before synthesis prevents the entire downstream analysis from being built on an untested assumption.
+
+If the user identifies a testable claim, run a targeted research agent to check it. This is cheap (~25-50K tokens) and can fundamentally change the quality of the synthesis.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-determinate-negation.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-determinate-negation.md
@@ -1,0 +1,45 @@
+# Phase 4: Determinate Negation
+
+This is the structural analysis phase. You (the orchestrator) perform this yourself — do NOT delegate to a subagent, because you need to maintain continuity with the elenctic interview and your domain research.
+
+## This phase is staged — read one stage file at a time
+
+Phase 4 is long, so it is split across four stage files. **Do not read them all at once.** For each stage, in order:
+
+1. Read the stage file.
+2. Do its work.
+3. **Write that stage's output to `round_N_determinate_negation.md`** before moving on.
+4. Then — and only then — read the next stage file.
+
+The framing in *this* index applies to every stage. Section numbers are continuous across the stage files, so a cross-reference like "see 4.6.5" points to whichever stage holds that section.
+
+| Stage | File | Sections | The move |
+|---|---|---|---|
+| A | `reference/phase4-stage-a-analysis.md` | 4.0–4.4 | Find the collision |
+| B | `reference/phase4-stage-b-lateral.md` | 4.5a/b/c | Build the sea (donor pipeline) |
+| C | `reference/phase4-stage-c-decomposition.md` | 4.6, 4.6.5, 4.6.6 | Shatter, recombine, instrument |
+| D | `reference/phase4-stage-d-criteria.md` | 4.7, 4.9 | Sublation criteria + HARD STOP checkpoint |
+
+Writing each stage to file as you finish it is not optional bookkeeping — it is what makes the staging safe. If context is compacted between stages, the completed work survives on disk.
+
+## Framing that applies to all stages
+
+**N-monk scaling.** The default is 2 monks but Phase 1c.1 may have added a 3rd or 4th. The machinery below scales naturally — each monk gets its own determinate negation, the Boydian decomposition gets richer (more atomic parts in the "sea of anarchy"), and most lenses work N-way without rewrite. A few specific adjustments with 3+ monks:
+
+- **4.2 Shared Assumptions:** Ask "what do *all N* monks share that none realize they share?" Then separately note any *pairwise* assumptions that two monks share but the third doesn't — pairwise coalitions are themselves a structural finding, sometimes the main one.
+- **4.2.5 Position Protection:** Run the protection analysis per monk. Then ask whether there's a disguised shared interest *all N* tacitly need (the strongest finding) — or only a pairwise subset (the next strongest).
+- **4.3 Determinate Negation:** One per monk. Failures should be complementary across *all N*, not just pairwise — if Monk A's failure is only complementary to B's and not to C's, the triangle isn't closing and one monk may be redundant.
+- **Lens D (undecidable):** Check each candidate undecidable word across all N monks. The strongest undecidables are loaded differently by *every* monk; pairwise-opposite loadings are weaker but still worth naming.
+- **4.5b Random domain injection:** Unchanged — cross-domain material doesn't scale with monk count.
+
+Where the stages below say "both monks" or "each agent" read it as "every monk" when N>2.
+
+**Context management:** By this point your context contains the full elenctic interview, research results, both essays, and any supplementary research. If context is getting large, summarize research and essays into their structural essences before beginning analysis. You need the *shape* of the arguments — the ontological claims, the key evidence, the failure diagnoses — not every word. Write your full Phase 4 analysis to `round_N_determinate_negation.md` as you go (one stage at a time, per the protocol above). When you reach the user checkpoint (4.9), present only a concise summary.
+
+Read both monks' outputs and analyze using the exact structure laid out in the stage files.
+
+**Treat monk output as testimony, not evidence.** Monks pushed to full conviction will sometimes overstate mechanisms, present uncertain claims as settled, or make rhetorically compelling leaps. Work with the *structure* of their arguments — what they're actually claiming, where the real collision is, what assumptions they share — not their rhetoric. If a monk asserts something that smells like confabulation, note it and don't build your synthesis on it.
+
+**Before you begin: write down your current best guess at the synthesis in one sentence.** Set it aside. Compare at the end of Phase 5 — if they're substantially similar, you may be pattern-matching rather than genuinely synthesizing.
+
+Now read `reference/phase4-stage-a-analysis.md` and begin.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-stage-a-analysis.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-stage-a-analysis.md
@@ -1,0 +1,62 @@
+# Phase 4 — Stage A: Core Analysis (4.0–4.4)
+
+*Read the framing in `reference/phase4-determinate-negation.md` first if you haven't. This stage finds the collision: the surface contradiction, each position's self-sublation, the shared assumptions, position protection, the determinate negations, and the hidden question.*
+
+## 4.0 Surface Contradiction
+State the apparent disagreement in its simplest form. What does each side think the argument is about? This orients the entire analysis — everything below is exploring why this surface disagreement is more interesting than it looks.
+
+## 4.1 Internal Tensions (Self-Sublation)
+
+Now analyze each essay *in isolation.* Where does Monk A's own argument, pushed to its logical extreme, undermine its own premises? Where does Monk B's internal logic generate contradictions it can't resolve? This is Hegel's self-sublation — the position contains its own negation.
+
+The deepest synthesis material often comes not from where the monks *disagree with each other* but from where each position *disagrees with itself.* A monk that argues for decentralization but keeps needing coordination mechanisms is undermining itself. A monk that argues for integration but keeps carving out exceptions is undermining itself. These internal fractures point toward what each position is *trying to become* — which is often where the synthesis lives.
+
+## 4.2 Shared Assumptions
+Identify what BOTH agents implicitly agree on that they don't realize they agree on. These shared assumptions are often where the real limitation lives. Probe:
+- Do both assume the same unit of analysis?
+- Do both assume the same problem is central?
+- Do both assume a particular model of how their domain works?
+- What frame constrains both of their visions?
+
+## 4.2.5 Position Protection (Ricoeur — hermeneutics of suspicion)
+
+Shared assumptions (4.2) are *conceptual* — what both positions unknowingly take as given. Position protection is *motivational* — what each position has a stake in remaining true. Different object. Run this BEFORE determinate negation, because the disguised shared interest often reshapes what counts as the "specific missing thing" each position fails to see.
+
+For each Monk, answer:
+- What is this position *protecting*? What would someone who holds it lose if it were wrong?
+- What constituency or identity benefits from this position remaining a live option?
+
+Then:
+- **Do both positions share a disguised common interest — something they both tacitly need to stay true?** The debate itself may be a distraction from the interest both sides share.
+
+Examples from test runs:
+- react-vue: both positions need the *named-human framework author's taste* to remain the relevant variable. Neither can survive a world where compilers, standards bodies, or AI make that judgment fungible.
+- european-miracle: both positions need "the Industrial Revolution" to be a *bounded event explicable by a small causal set*. High-dimensional emergent causation would make both research programs merely descriptive.
+- garden-design: both positions need the yard to be *one coherent design-object with a single organizing principle*. A loose coalition of zones doesn't serve either frame.
+
+Write the output of this lens to the misfit register (see 4.6.5 for format). If a disguised shared interest surfaces, carry it into 4.3: the *real* determinate negation of each Monk may be "fails to see that its position is a local variation of a shared interest it cannot examine." If nothing surfaces, write "no visible protection misfit" and move on — don't force it.
+
+**Citation requirement:** Cite the exact passage in each Monk's essay where the protective structure is visible. Uncited claims in this lens are high-risk for confabulation.
+
+**Check the watchlist.** Before writing, skim `reference/misfit-patterns-watchlist.md`. If a previously-seen cross-domain pattern applies here, note it — convergent evidence across dialectics is itself a finding.
+
+## 4.3 Determinate Negation
+For each agent, identify the SPECIFIC way it fails — not "it's wrong" but "it fails in THIS specific way, which points toward THIS specific thing missing from its worldview."
+
+**Determinate negation is the engine of the dialectic.** It is not:
+- "Monk A is wrong" (abstract negation — useless)
+- "Both have merits" (compromise — useless)
+
+It IS:
+- "Monk A fails because [SPECIFIC FAILURE], which reveals [SPECIFIC MISSING THING]"
+- "Monk B fails because [SPECIFIC FAILURE], which reveals [SPECIFIC MISSING THING]"
+- The failures are COMPLEMENTARY — each agent's blind spot is something the other can partially see, but neither sees the whole.
+
+If 4.2.5 surfaced a disguised shared interest, the determinate negation of each monk may read: "fails to see that its position is a local variation of a shared interest it cannot examine — specifically [the interest]."
+
+## 4.4 The Hidden Question
+Articulate the deeper question the contradiction is ACTUALLY about — the question neither agent asked because they were both too committed to their answers. This should reframe the entire debate in a way that makes both positions legible as partial truths.
+
+---
+
+**Before moving on:** write your 4.0–4.4 analysis to `round_N_determinate_negation.md`. Then read `reference/phase4-stage-b-lateral.md`.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-stage-b-lateral.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-stage-b-lateral.md
@@ -1,0 +1,81 @@
+# Phase 4 — Stage B: Lateral Creativity Interventions (4.5)
+
+*This stage builds the "sea of anarchy" you will shatter in Stage C: compressed conflicts, a multi-domain donor pool recruited blind, and a non-propositional pause. Do this BEFORE the Boydian decomposition so the new material becomes atomic parts in the decomposition rather than an afterthought.*
+
+## 4.5 Lateral Creativity Interventions
+
+Lateral interventions surface vocabulary and structural frames that within-domain analysis cannot produce. In later rounds the value compounds — the synthesis is pushing past its own limits and the vocabulary is running out — but the cross-domain material is high-leverage from the start.
+
+The dialectic processes everything through propositional structural analysis. That channel is powerful but it can only recombine existing conceptual vocabulary — it cannot generate *new* vocabulary. The following interventions force the mind to process the problem through channels it wasn't using.
+
+**These interventions come BEFORE the Boydian decomposition** so that the new material they produce becomes atomic parts in the decomposition. Running decomposition first means you shatter and recombine within the same conceptual space, then bolt on random domains as an afterthought. Running lateral interventions first means the random domains get decomposed and cross-connected alongside the monks' material — producing genuinely new combinations.
+
+### 4.5a Compressed Conflict Generation
+
+Express each core tension from the determinate negation (4.3) as a **two-word oxymoron** — a "compressed conflict" (from Gordon's Synectics). Examples: "productive dissipation," "autonomous dependence," "structured spontaneity," "durable ephemerality."
+
+Generate 5-7 compressed conflicts. Select the 2-3 most resonant ones to guide synthesis direction.
+
+**Why this works:** The oxymoron format holds the contradiction as a *unit* rather than resolving it. It encodes the tension in a form that resists premature resolution — exactly what you want before synthesis.
+
+### 4.5b Donor Recruitment for the Sea of Anarchy
+
+Boyd's snowmobile is built from four shattered domains (skis, outboard motor, handlebars, treads), each chosen for the *operation* it contributes. Two monk-positions plus one skimmed article is too thin a sea. This step **recruits donor domains** that get decomposed alongside the monks in 4.6 at equal depth — not garnished on afterward. Recruit from two streams:
+
+**Random donors (novelty / anti-habit).** The orchestrator picking a "random" domain filters through its own conceptual habits. Wikipedia's randomness is genuinely external. **Use curl (via bash)** — WebFetch/fetch tools return 403 on Wikipedia:
+
+```bash
+curl -s "https://en.wikipedia.org/w/api.php?action=query&list=random&rnnamespace=0&rnlimit=50&format=json"
+```
+
+To get extracts for promising ones:
+```bash
+curl -s "https://en.wikipedia.org/w/api.php?action=query&titles=ARTICLE_TITLE&prop=extracts&exintro=true&explaintext=true&format=json"
+```
+
+Scan titles, fetch extracts for the ones maximally distant from the dialectic's domain with enough conceptual density (not stubs). Typically 5–8 of 50 have substance.
+
+**Functional donors (operation-targeted, recruited *blind*).** The trap: if you pick these yourself you know the home domain, so you reach for its nearest neighbors — a strategy problem pulls "central-bank independence" and "TCP/IP," which are adjacent fields in a costume, not cross-domain injections. Relevance without distance is recombination, not creation. Defeat the bias by recruiting blind:
+
+1. **Write a domain-neutral structural brief.** **What becomes a brief:** one brief per determinate-negation "missing thing" (4.3) — these are mandatory, the floor. You *may* add briefs for hidden questions (4.4), cross-cutting tensions, or compressed conflicts when they open a genuinely different domain — more relevant domains make a richer snowmobile. **Label each brief with its source** (`negation-A`, `negation-B`, `hidden-Q`, …); the allocation rule in step 4 reads these labels. Render each as an abstract *relational pattern* with **every home-domain noun stripped** — no industry, company, product, or technology words. E.g. "a mechanism by which a part keeps its function after being absorbed into a larger whole whose survival does not depend on that part" — *not* "how an acquired team keeps its mandate." Strip out acronyms, named standards, and single-field terms of art too (`MUST/SHOULD/MAY` names the home domain as loudly as a product name). You are the leaker and **cannot see your own leak** (curse of knowledge), so don't rely on re-reading your own brief — the real leak check runs at step 3, where the blind recruiter reports the domain it infers. A leaked brief re-infects the recruiter with your bias.
+2. **The field palette — the recruiter fetches it, you don't hand-curate it.** A hand-written menu is partial and carries the orchestrator's bias (the exact thing we're fighting). Use Wikipedia's *Outline of academic disciplines* as an authoritative, comprehensive taxonomy. Academic disciplines are the right register on two counts: they stay broad (the outline spans the whole map of knowledge), and they *formalize and document* their key abstractions — so the concepts arrive pre-articulated in transferable form, which is exactly what the step-5 research pass needs to extract and shatter. **The recruiter reads the page itself — you do not pre-digest it.** Put the fetch command below in the recruiter's prompt and let it read the *full* result. Do NOT fetch the outline yourself and paste in a summarized menu: any condensing re-curates the list through your bias (e.g. collapsing the entire Life science branch to "Biology"), which is exactly the failure this step exists to prevent — and it hides the breadth the recruiter is meant to choose against (the ≤1-life-science cap is meaningless if the recruiter never sees how deep the *other* branches go). Fetch the complete wikitext, which includes every discipline *and* its subdisciplines as nested list items, not just top-level headings:
+
+   ```bash
+   curl -s "https://en.wikipedia.org/w/api.php?action=parse&page=Outline_of_academic_disciplines&prop=wikitext&format=json"
+   ```
+
+   The disciplines are grouped under five top-level meta-domains: **Humanities** (1), **Social science** (2), **Natural science** (3, splitting into Physical science 3.1 and Life science 3.2), **Formal science** (4), **Applied science** (5). The recruiter ranges across as many of the five branches as possible. (The recruiter may also pull a few random Wikipedia articles — as in the random-donor stream — to surface fields the academic outline thins out, e.g. crafts and folk practices.)
+3. **Dispatch the blind recruiter** with ONLY the structural briefs + the step-2 fetch command so it reads the full Outline page itself (no problem, no home domain, no monk essays, no pre-summarized palette). Put these hard constraints in its prompt:
+   - **Leak check FIRST, before recruiting:** name the single domain these briefs most smell like. If you can name a specific home field, or you spot any acronym, named standard, proper noun, or single-field term of art in a brief, say so and stop. — If the recruiter names your actual home domain (or flags a brief), the briefs are contaminated: re-strip the flagged brief and re-dispatch. This is the real leak gate; the orchestrator's own re-read (step 1) cannot catch its own curse-of-knowledge.
+   - **Maximum meta-domain diversity is the PRIMARY objective** — not a tiebreaker applied after fit. Across all picks, span the widest possible range of the five branches.
+   - **At most ONE pick from the Life science branch (3.2) and its children.** Biology/ecology/medicine read as the most mechanistically legible and are the lazy default — cap them at one across all patterns.
+   - **Over-generate: 4 candidate domains per pattern,** each naming a *specific technical concept* from that field plus one sentence on the structural match. No vague "law handles this" — name *adverse possession*, *ratio decidendi*, *littoral drift*, *Schenkerian reduction*.
+   - **No two picks from the same broad field;** if a field repeats across patterns, flag it and offer a swap.
+
+   Enforced ignorance: it never sees the home domain, so it pattern-matches structure, not nearest-neighbors.
+4. **Rank and finalize (orchestrator) — hard no-clustering rule.** From the recruiter's over-generated candidates, pick the final 3–5 functional donors to **span as many unrelated meta-domains as possible** — living systems, physical systems, social/institutional, formal/mathematical, linguistic/cultural, artistic. Require **≥3 distinct meta-domains; never two donors from the same one.** This rule binds *you, the selector*, because the conceptual-habit bias re-enters precisely here: you will be tempted to collapse the set onto the meta-domain whose mechanisms read as most *legible and rich* to you (for many orchestrators, biology). **That legibility IS your habit** — the exact filter the blind recruiter just worked to defeat, sneaking back one step downstream at selection. The recruiter will have offered spread (linguistics, law, folklore, mycology, ritual…); do not quietly drop the less-legible ones. If two patterns' best match share a meta-domain, the second takes its strongest donor from a different one, even at some cost to per-pattern fit. Monoculture is a failure mode: a sea that is all one meta-domain inherits that domain's deep priors (e.g. biology's selection / fitness / organism-boundary) and its diversity is illusory.
+
+   **Allocation: negations are the floor, then breadth — write the manifest.** Before research, write a `pattern → donor(s)` table, each pattern tagged with its source from step 1. Two hard rules:
+   - **Cover every determinate negation first.** Each negation gets ≥1 donor *before* any pattern gets a second and *before* any hidden-question / cross-cutting pattern gets any. A sea with two donors for Monk A's gap and none for Monk B's silently re-arms one side of the dialectic and starves the other — the synthesis then leans toward the well-donored side for reasons that have nothing to do with the argument. Negation coverage first, then breadth, then meta-domain spread.
+   - **The prior must not out-arm the gaps.** Hidden-question briefs are welcome — more relevant domains make a richer snowmobile — but if a hidden-question brief restates your **pre-analysis synthesis guess**, tag it `[prior-overlap]` and give it **no more donors than each negation pattern has**. The prior has to assemble itself out of a sea stocked at least as well for the gaps; it does not get to recruit its own confirmation. If the synthesis later lands on your pre-analysis guess, this table is the first suspect (the dislodgement test: rebalance the sea and re-run — a guess that survives a gap-stocked sea is real; one that doesn't was a donor-stacking artifact).
+
+   **The manifest is a commitment, not a shortlist.** Every donor you select gets decomposed at equal depth (step 5). Do not pick a diverse-looking set and then quietly drop the unfamiliar ones — that is the legibility bias laundering itself through a compliant-looking selection. If you genuinely must drop a selected donor, log why *and replace it* from the recruiter's pool; never just shrink the sea toward what you already understand.
+5. **Research each donor domain, then decompose at equal depth in 4.6.** For each finalized domain do a research pass — the recruiter can continue, or dispatch one researcher per domain in parallel — that surfaces the *field's own* concepts, mechanisms, and technical vocabulary around the abstract pattern (for immunology: clonal selection, central vs. peripheral tolerance, immunosuppressant maintenance dosing — not a layperson sketch of "rejection"). Keep the researcher focused by the abstract pattern but **still blind to the home problem**, so the donor material is gathered on its own terms and gets shattered by you (who knows the problem), not pre-bent toward the answer — the same decorrelation that keeps the monks honest. The field's real vocabulary is where new synthesis vocabulary comes from; Boyd's whole point is that within-domain recombination cannot generate it. Then shatter these field-accurate writeups into atomic parts in 4.6 at the same depth as the monks. (Snowmobile logic — donors chosen for the function they contribute. Test-run evidence: a biology donor, organ-rejection-requires-active-immunosuppression, out-produced two business-adjacent donors precisely because it came from far away.)
+
+   **Equal depth means equal — and the bias makes its last stand here.** The legibility habit reappears at the research step: you will be tempted to deeply research the donor you already half-understand and wave the foreign one through "conceptually, without deep research" — or drop it outright. That silently re-stacks the sea toward what you already know and defeats the entire blind pipeline. The *distant, less-legible* donor is the one most likely to carry genuinely new vocabulary, so it earns equal or *more* research time, never less. If a donor is too unfamiliar to research, that is exactly why it belongs in the sea — not a reason to discard it.
+
+One special case the blind brief handles naturally: when a monk makes a claim that *resists* analytical treatment, the abstract pattern will pull domains that take that kind of claim seriously on their own terms (4.6 step 5 verifies this happened).
+
+**Pool size:** the N monks **+ ~3–5 donors**, weighted toward functional donors with 1–2 random donors for anti-habit novelty. Each donor is a first-class domain entering 4.6's decomposition at the **same depth as the monk positions** — not a 2–3 paragraph isomorphism garnish. List the donors in the 4.6 domain manifest. The actual isomorphism-finding moves to 4.6 step 3, where donors are already decomposed as peers.
+
+**Why this works:** Boyd's cross-domain step made mandatory *and* multi-domain. Domain distance correlates with novelty; functional targeting correlates with relevance — you want both. Within-domain recombination cannot produce new vocabulary; a deep, functionally-targeted sea can.
+
+### 4.5c Non-Propositional Pause
+
+Before proceeding to decomposition, pause the analytical engine. Write **three metaphors** for the contradiction you just analyzed. Not explanatory metaphors — evocative ones. What does this tension *feel like*? What does it *look like*? What does it *sound like*?
+
+Keep this to 2 paragraphs maximum. Extract 3-5 structural observations from the metaphors before proceeding.
+
+---
+
+**Before moving on:** write your 4.5 output — the compressed conflicts, the donor pool (with the domain manifest you'll carry into 4.6) and per-donor research, and the metaphor observations — to `round_N_determinate_negation.md`. Then read `reference/phase4-stage-c-decomposition.md`.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-stage-c-decomposition.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-stage-c-decomposition.md
@@ -1,0 +1,101 @@
+# Phase 4 — Stage C: Boydian Decomposition + Registers (4.6, 4.6.5, 4.6.6)
+
+*This stage is the destructive heart of the phase: shatter every domain in the pool (monks + donors from Stage B) into atomic parts, find cross-domain connections, recombine into something with emergent structure, then instrument what the synthesis will leave un-resolved (misfit register) and what it would smooth away (loss audit).*
+
+## 4.6 Boydian Decomposition (Destruction Phase)
+
+**Now shatter both positions — AND the lateral material from 4.5 — into their atomic parts.** This is Boyd's *destructive deduction*: break the correspondence between each domain and its constituents, producing "many constituents swimming in a sea of anarchy."
+
+**Heisenberg check (observer perturbs observed).** The act of analysis bends the positions toward synthesis — you start reading each monk as already half-reconciled with the other. Before shattering, verify you are decomposing what each monk *actually committed to* (its testimony in the essay), not a pre-smoothed version your analysis has nudged toward the middle. This is Boyd's second pillar made operational: observation disturbs the observed.
+
+Concretely:
+1. **Identify the generic space** — the abstract relational structure both positions share. Both assume a particular unit of analysis, a particular causal model, a particular temporal frame. This shared structure is the skeleton they're both building on, and often the thing the synthesis needs to transcend.
+2. **Construct the sea of anarchy.** First write a **domain manifest** — an explicit list of every domain in the pool as peers: `[Monk A, Monk B, (Monk C…), donor1, donor2, donor3…]` (donors recruited in 4.5b). Every entry on the manifest gets decomposed to the **same depth** — this is the guard against the monk-primary habit of shattering the essays thoroughly and skimming the donors. Then **list the atomic components** of every domain on the manifest — claims, mechanisms, evidence, assumptions, metaphors, principles, operations — stripped of which monk or donor said them.
+
+   **Tag each part with a calibration estimate — and use the right axis for the source.** Two different axes, two different tags; do not blur them:
+   - *Monk-derived parts* → tag **claim support** as `[solid]` / `[plausible]` / `[reach]`, independent of how confidently the monk asserted it. The monks argue at full conviction by design; calibration is per-part and the synthesis weights by it (Phase 5), not by rhetorical force.
+   - *Donor-derived parts* → do **not** tag home-field truth. Assume the blind research is reliable; every textbook fact would trivially read `[solid]` and the tag would do no work. Instead tag **isomorphism strength to the problem** with an explicit, un-skippable `[fit: solid|plausible|reach]`. A fact can be rock-solid in its field and a `[fit: reach]` as applied — the elegant mapping that exists because the donor concept *has* a referent, not because it is load-bearing. Every donor part carries a `[fit:]` tag, no exceptions.
+
+   The recombinations produced in step 4 get their own `[fit:]` tags — the recombination, not the raw part, is where the synthesis risk actually lives.
+
+   **Anti-tidiness check (genuine destruction).** The result must be a genuinely *unstructured* collection — Boyd's "sea of anarchy." If your parts already sit in neat thematic groups, or are organized by which domain they came from, you have smuggled in a structure and the destructive step has failed. A clean taxonomy is itself an imported frame. Scramble it: provenance forgotten, no pre-categorization.
+3. **Find common qualities, attributes, *or operations* (Boyd's exact phrase) — as three explicit passes.** Boyd names three distinct search targets; run each, don't collapse them:
+   - **Qualities** — shared static properties (both are fragile; both self-reinforce; both decay without input).
+   - **Attributes** — shared relational or contextual features (both depend on a boundary; both presuppose an observer; both are scale-sensitive).
+   - **Operations** — shared *functions* / dynamics / what the part *does* (both propagate; both gate flow; both convert one form into another). **This is the highest-yield pass and the one most often skipped** — the snowmobile is an operations recombination (gliding + propulsion + steering), not an appearance recombination. Run it explicitly even when qualities/attributes already produced hits.
+
+   The highest-value connections are typically between donor material and monk material. This is where the isomorphism-forcing happens — the donors are already decomposed as peers (from 4.5b + the manifest), so you are connecting liberated parts, not bolting a domain on.
+4. **Recombine — not in the same arrangement.** Build connections among the liberated parts. Boyd is explicit: the result must NOT use the parts in the same arrangement as any original domain — if you've merely reassembled one monk's structure with different vocabulary, you haven't created anything. (Donors are recruited up front in 4.5b; if the decomposition reveals a *missing* operation that no donor on the manifest covers, recruit one more functional donor now and decompose it to equal depth before proceeding.) **Tag each recombination with a `[fit: solid|plausible|reach]`** — how load-bearing the cross-connection is for the synthesis, not how true either part is in its home field. An untagged recombination is incomplete; the elegant-but-thin mappings (a donor concept that lands a referent without doing work — e.g. "the most stable crystal form = bloom, therefore maximum independence = ruin") must surface as `[fit: reach]` so Phase 5 does not build its spine on them.
+5. **Epistemological diversity verification.** If a monk claims something *resists* analytical/propositional treatment (love, wisdom, quality of attention, aesthetic judgment, faith, embodied knowledge), confirm the manifest includes at least one functional donor that takes that claim seriously *on its own terms* — virtue ethics, contemplative traditions, care ethics, aesthetic philosophy, phenomenology. If every donor is itself analytical, the synthesis will dissolve the higher-order claim into lower-order terms (the level-reduction failure). If missing, recruit one now and decompose it.
+
+**Emergent structure test:** The synthesis must have organizational properties that exist in *neither* input. If every element of your synthesis is attributable to one monk or the other, you've recombined, not created.
+
+**Same-arrangement test (Boyd):** Even if the synthesis has new properties, check whether the *structural relationships* between its parts mirror one of the original domains. A synthesis that is Monk A's architecture wearing Monk B's terminology has emergent vocabulary but not emergent structure.
+
+## 4.6.5 Misfit Register
+
+This pass instruments where the frame scraped. You are NOT trying to escape the frame here; you are capturing friction for later aggregate rereading. Most items here will go un-resolved by the synthesis. That is correct. **A misfit that gets resolved has stopped being a misfit — it has become synthesis material.** The register's value is the *un-resolved residue.*
+
+The premise: most dialectics are single-loop — they enrich within a stable frame, and that is correct. Frame-level (double-loop) work happens on a longer cycle by periodically rereading the accumulated misfit register across many dialectics. This round, you only need to instrument where the frame scraped.
+
+Run four lenses here (position-protection already ran at 4.2.5 and is written to the same register). For each, produce 0-5 items. Zero is a valid answer. Err toward fewer, higher-signal misfits. **Each misfit must include a citation: briefing line, monk passage, or atomic-parts-list item it refers to.** Uncited misfits are high-risk for confabulation and should be dropped unless the citation can be produced.
+
+**Check `reference/misfit-patterns-watchlist.md`** before writing. If a previously-seen cross-domain pattern surfaces here, note it explicitly — convergent evidence across independent dialectics is itself a structural finding.
+
+### Lens A — Briefing residue (ground condition)
+Re-read the Phase 1 context briefing with fresh eyes. Which specific facts stated there is **neither Monk operating on**? Which concrete constraints did the debate vocabulary float past? Name the fact verbatim (with briefing line citation), then one sentence on why neither position engaged with it.
+
+*Example from garden-design: "The yard has no back door from the house" was in the briefing. Both monks debated rooms vs. flow; neither operated on access.*
+
+### Lens B — Synthesis residue (Adorno / non-identity)
+Scan the atomic parts list from 4.6. Which parts is the forthcoming synthesis likely to **drop or smooth over**? Which parts resist absorption — they don't fit any cross-domain connection you found, and they won't serve any sublation criterion? Cite the specific atomic-parts-list item. Name them now, before the sublation pressure kicks in and makes them invisible.
+
+Adorno's rule: the genuine object lives in the gap between concept and instance. A completed synthesis is a suspect synthesis; it has smoothed the non-identical. Test runs show this lens is most predictive for *extrinsic* misfits — physical constraints, stated preferences, affective registers, biographical specifics. Design-internal misfits (e.g., a feasibility paradox) tend to get preserved as explicit residual contradictions by the synthesis itself; they are not what Lens B is best aimed at.
+
+### Lens C — Framing genealogy (Foucault)
+One paragraph, no research trip. Where does the current binary come from? Is it a fossil of an older conflict that no longer applies? Who does the framing serve — which constituency benefits from the debate being stateable in *these* terms rather than others? If nothing obvious surfaces, write "no visible framing misfit" and move on. Don't force it.
+
+Citation here is lighter (framing analysis is interpretive) but name the specific era/conflict/constituency. Test runs consistently find that the fossil framing serves *producers of the discourse* (magazines, disciplinary specialists, tech media) rather than actual decision-makers — watch for that shape.
+
+### Lens D — Undecidables (Derrida)
+Is there a **word both Monks use with opposite meanings**? A term that appears prominently on both sides but loads oppositely — "engagement," "scale," "quality," "freedom," "design"? That word is often the actual object of dispute, and it is typically *not* resolvable by synthesis (Derrida's point: undecidables are not third terms, they are terms that refuse the binary).
+
+Name the word. Cite one passage from each Monk where the opposite loadings are visible. Do not try to resolve it.
+
+### Write the register
+Two files:
+
+**`round_N_misfits.md`** — full text of the four lenses above (plus the 4.2.5 position-protection material), with reasoning.
+
+**`misfit_register.md`** (at dialectic root, created if absent, appended to every round) — one line per misfit, with citation token:
+```
+R1/protection: both positions need yard to be one coherent design-object [monk_a:L42, monk_b:L28]
+R1/briefing: no back door to yard — access not addressed by either position [briefing:L15]
+R1/undecidable: "enclosure" — Monk A = walls; Monk B = canopy/screens [monk_a:L31, monk_b:L44]
+```
+
+Keep lines under 150 chars. Future cross-dialectic passes will grep across these files; terseness matters.
+
+**Anti-patterns to avoid:**
+- Listing everything that didn't make the synthesis (too noisy — filter for *structural* misfits, not arbitrary omissions)
+- Converting a misfit into a synthesis criterion (that's resolving it; defeats the purpose)
+- Inflating the lenses with forced finds (zero items is a valid answer per lens)
+
+## 4.6.6 Loss Audit — Single-Monk High-Value Ideas
+
+The misfit register (4.6.5) captures frame-level *friction* the synthesis will leave un-resolved. This pass captures the opposite failure: high-value *content* the synthesis will smooth away. Empirically, blending multiple model outputs drops most good ideas that appeared in only *one* output — the "hidden profile" problem (Stasser & Titus): groups over-sample shared information and lose what only one member held. The palette (Phase 5) is a partial guard; this pass makes it explicit.
+
+**Procedure:**
+1. **Extract single-monk ideas.** Scan the atomic parts list (4.6 step 2) for high-value ideas — mechanisms, observations, failure modes, reframes — appearing in **only one** monk. These "spiky" ideas are most at risk of being smoothed away.
+2. **Score provenance-blind.** Rate each for "useful, non-obvious, worth keeping" *without* reference to which monk produced it. Default: dispatch 2–3 fresh blind-judge subagents (no position, no sight of any synthesis) to score the stripped ideas — this removes the single-informed-seat bias. Minimum fallback: the orchestrator scores with provenance stripped. Use the 4.6-step-2 calibration tags as a second axis: **value × calibration.**
+3. **Coverage requirement.** Each high-value idea must be either (a) carried into a Phase 5 candidate, or (b) **consciously dropped with a one-line reason** logged to `misfit_register.md`. Silent dropping is the failure this pass exists to prevent. A high-value + low-calibration idea is carried as a *flagged hypothesis* that must earn evidence (the Phase 5 reversibility-repair path), not asserted.
+
+**Boundary with the misfit register — do not conflate:**
+- Loss-audit items are *absorbable high-value content* — smoothing them away is the bug, so **recover** them. Test: "would carrying this in make the synthesis *better*?"
+- Misfit-register items are *frame-level friction* — forcing them to fit falsifies the synthesis, so **preserve** them un-resolved. Test: "would absorbing this *falsify* the synthesis?"
+
+**Write the output** to `round_N_loss_audit.md`: each single-monk idea, its value × calibration score, and its disposition (carried-to-S / carried-to-J / dropped + reason).
+
+---
+
+**Before moving on:** confirm you've written `round_N_misfits.md`, `round_N_loss_audit.md`, the `misfit_register.md` appends, and the full decomposition into `round_N_determinate_negation.md`. Then read `reference/phase4-stage-d-criteria.md`.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-stage-d-criteria.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase4-stage-d-criteria.md
@@ -1,0 +1,39 @@
+# Phase 4 — Stage D: Sublation Criteria + User Checkpoint (4.7, 4.9)
+
+*The final stage of Phase 4: state what the synthesis must accomplish, then HARD STOP and present a concise summary to the user. This is the highest-leverage correction point in the entire process — do not skip the stop.*
+
+## 4.7 Sublation Criteria
+Before synthesis, specify what it must accomplish:
+- Preserve [specific insight from A]
+- Preserve [specific insight from B]
+- Dissolve [the shared assumption both are trapped in]
+- Answer [the hidden question]
+
+Separating criteria from synthesis prevents pattern-matching to a pre-formed compromise.
+
+**Do not add misfits from 4.2.5 / 4.6.5 to these criteria.** The criteria are what the synthesis must do. The misfits are what the synthesis will leave un-done. Mixing them defeats the register.
+
+## 4.9 Present the Negation to the User — STOP HERE
+
+**Do NOT proceed to Phase 5 without presenting your Phase 4 analysis to the user and getting their response.** This is a hard stop, not a suggested checkpoint.
+
+The full Phase 4 analysis is already written to file — the user can read it there. **Present a concise structural summary**: the hidden question, the key determinate negations (1-2 sentences each), the most surprising decomposition insights, the sublation criteria, and **1-2 highest-signal misfits from the register** (not all of them — just the ones that might change the user's response).
+
+**Prime the donor domains.** The user is expert in the home domain but the donors are deliberately distant — by the time the summary leans on "kinetic quenching," "restite," "ubiquity–authorship inverse coupling," or "the metastable Form-V target," an unprimed user cannot evaluate the recombination, and this is the highest-leverage correction point in the whole process. So for each donor whose vocabulary appears in the surfaced insights, include a **crisp, directed primer — 2-4 sentences** explaining *exactly the borrowed mechanism* (not the whole field) in terms of the user's problem. You earned the right to write a tight primer rather than a generic one: you did the blind research and you know which connection you're drawing, so prime only the slice the isomorphism actually uses. A user who can't follow the donor can't tell you the isomorphism is forced — which is precisely the `[fit: reach]` check you most need them to run.
+
+Then ask:
+
+> Here's my structural analysis of the contradiction. Before I attempt synthesis:
+> - **Did I identify the right hidden question?** Or is the real tension somewhere else?
+> - **Did I miss anything in the decomposition?** New connections, evidence, or angles that should be in the mix before I synthesize?
+> - **Are the sublation criteria right?** What must the synthesis preserve that I haven't listed?
+> - **Do the flagged misfits look right,** or am I missing a bigger one?
+> - **Are the recovered high-value ideas right,** and do the conscious drops look correct — or did I smooth away something that should be carried?
+>
+> This is the highest-leverage correction point — it's much harder to fix the synthesis after I've committed to a direction.
+
+**Anti-sycophancy at this checkpoint:** When the user provides input here, evaluate it structurally, not socially. Do NOT say "this is excellent material." Instead: What does this material do to the decomposition? Does it challenge the hidden question? Does it open a new domain for cross-connection? Does it actually change anything, or is it confirming what the analysis already found? If the user shares a framework they're excited about, it enters the mix as one more input to be shattered and recombined — not as the answer the synthesis should converge on. The user is in the belief-free seat. Do not try to locate their position and build toward it.
+
+---
+
+This is the end of Phase 4. After the user responds at the 4.9 checkpoint, proceed to Phase 5 (`reference/phase5-sublation.md`).

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase5-sublation.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase5-sublation.md
@@ -1,0 +1,213 @@
+# Phase 5: Palette of Candidates
+
+Phase 5 generates a **palette of structurally-distinct Phase-5 candidates**, not a single synthesis. Each candidate has a different posture toward the contradiction — synthesize it, juxtapose it, ground it out, dissolve the frame, or center the undecidable term. The user picks or combines; the orchestrator does NOT rank, judge, or tournament.
+
+**Why a palette:** Hegel's Aufhebung (cancel/preserve/elevate) structurally biases toward smoothing differences into a single unified answer. That's often boring and sometimes wrong — the real value of the dialectic up to this point (research, belief, decomposition, misfit registration) is in generating *many angles*, and Phase 5 has been squandering that by collapsing back to one. The palette preserves the angles.
+
+**No ranking, no winner.** The user is belief-free and in the judging seat. Orchestrator's job is to produce maximally distinct candidates so the user has real options.
+
+## 5.0 Candidate Selection
+
+Five candidate types exist. **S is always drafted.** The others are drafted **conditionally** based on which misfit-register lenses fired non-trivially in 4.2.5 / 4.6.5:
+
+| Candidate | Posture | Fires when |
+|---|---|---|
+| **S — Synthesis** (Hegel) | Cancel/preserve/elevate into a new concept that transforms the question | Always drafted |
+| **J — Juxtaposition** (Adorno / Derrida / Koestler) | Refuse unification; hold the contradiction open; zones have locally-sovereign logics | 4.2.5 surfaced a disguised shared interest, OR Lens B found parts the synthesis will smooth over |
+| **G — Ground condition** (Lens A / Schumacher) | A specific material fact or higher-level factor makes the debate moot; resolution lives at a different level of being | Lens A caught concrete briefing residue, OR the domain plausibly has a level-shift resolution (love/attention/character/relationship/physical constraint) |
+| **F — Framing dissolution** (Foucault) | The debate is a fossil of an earlier conflict serving a specific constituency; the actual decision-makers face a different-shaped question | Lens C surfaced a fossil framing |
+| **U — Undecidable-centered** (Derrida) | Name the word both sides use oppositely as the real object; refuse to resolve it | Lens D caught a strong undecidable |
+
+Open the top of the Phase 5 file by listing which candidates will be drafted and why, citing the specific lens findings. If only S fires (all other lenses were "no visible misfit"), draft only S. Don't force candidates the register didn't earn.
+
+**Target:** typically 2-4 candidates. Fewer than 2 is suspect — re-read the register; a second lens usually earned at least a draft. More than 4 and the user can't hold the palette; collapse the weakest.
+
+## 5.1 Generate Candidates in Parallel (Decorrelation)
+
+**Dispatch one subagent per candidate type.** Each subagent receives:
+- The context briefing (Phase 1)
+- Condensed summaries of both monk essays
+- The Phase 4 determinate negation, hidden question, sublation criteria (for S) and atomic parts list
+- **Only the lens material relevant to its candidate** (e.g., G-agent gets Lens A; F-agent gets Lens C)
+- Its own candidate-type spec (below)
+
+**Do NOT give any subagent sight of sibling candidate drafts.** Decorrelation is the point — if the J-agent reads the S draft first it will subconsciously complement/refute rather than produce an independent candidate. Each candidate should stand on its own and be judgable against its own internal standard, not against the other candidates.
+
+**Orchestrator writes S itself** (does not delegate to a subagent). The orchestrator has the full Phase 4 continuity needed for the abduction test, reversibility check, and closure property. Delegating S loses that continuity.
+
+**Subagents return to orchestrator.** Orchestrator compiles the palette, does NOT synthesize across candidates, does NOT rank them, does NOT recommend one.
+
+### Length budget
+
+**S has no hard cap.** S carries a lot of machinery — provocation (Round 2+), cancel/preserve/elevate moves, abduction test, reversibility check, failure-mode tests, model update, new contradictions. Typical S length: 2000-3000 words.
+
+**J / G / F / U default to ~1000 words, hard cap 1500.** These candidates have a tighter structural job — name the refused interest (J) / ground condition (G) / fossil framing (F) / undecidable word (U), cite the supporting passages, articulate what the move reveals, state the failure modes avoided. They do NOT need to match S's length. In testing, 2500-word non-S candidates were padded — the conceptual meat was ~1000 words and the rest was restatement. Write tight; if a candidate genuinely needs more room, extend, but default short.
+
+When dispatching subagents for J/G/F/U, state the word budget explicitly: "Write the candidate at ~1000 words. Hard cap 1500. Do not pad to match S's length — non-S candidates are structurally tighter."
+
+## 5.2 Candidate S — Synthesis (Hegel)
+
+This is the classical Aufhebung candidate, written by the orchestrator.
+
+### Provocation Before Synthesis (Round 2+ Only)
+
+**Skip this in Round 1.** In Round 2+, before writing S, apply one De Bono provocation to disrupt premature pattern-matching:
+- "PO, the contradiction doesn't exist."
+- "PO, both monks are arguing the same position."
+- "PO, the synthesis was obvious from the start and we wasted our time."
+- "PO, the user's real problem has nothing to do with either monk's framing."
+
+Then apply movement techniques (extract a principle, focus on the difference, special circumstances). One provocation, three movement extractions, 1-2 paragraphs.
+
+### S must
+
+1. **CANCEL** both original positions as complete truths
+2. **PRESERVE** the genuine insight in each
+3. **ELEVATE** to a new concept that transforms the question itself
+
+### S internal standards
+
+**Abduction test.** If someone heard S first, would they predict the approximate shape of both monks' positions? If yes, genuine reframing. If no, likely just compromise. Aim for propositional-conditional-creative abduction (a genuinely new concept or structural principle), accept conditional-creative (new relationship between known concepts) if it resolves the contradiction, push harder if only selective.
+
+**Reversibility check (Boyd) — repair, don't reject.** Trace each major claim back to specific atomic parts from the decomposition. When a claim doesn't trace back, do NOT discard the whole synthesis — Boyd's instruction is to repair: keep the parts that cohere, add new material (recruit a new donor domain or do fresh research), and re-derive. Loop up to 3 times. After that, the untraceable claim either earns its own evidence as a genuine new insight (kept, explicitly flagged as net-new) or is cut. Also run the "not the same arrangement" test: structurally, is S just one monk's architecture wearing the other's vocabulary? That fails.
+
+**Precision-vs-grip check (Boyd / Heisenberg).** Over-tightening S for precision and completeness loses its match to the messy reality it describes. A synthesis that feels suspiciously clean — every loose end tucked, no remainder — has usually squeezed past the resolution the evidence supports. Boyd's third pillar operationalized: if S has no residue, suspect it. Cross-check the misfit register (4.6.5) — the genuine residue should still be visible, not dissolved.
+
+**Calibration weighting.** Weight S's load-bearing claims by the calibration tags from 4.6, not by how forcefully a monk asserted them or how elegant a donor mapping reads. Two axes: monk parts tagged `[solid]/[plausible]/[reach]` for claim support; donor parts and recombinations tagged `[fit: solid|plausible|reach]` for isomorphism strength. Build S's spine from `[solid]` monk parts and `[fit: solid]` recombinations; treat `[reach]` and `[fit: reach]` parts as flagged hypotheses, not load-bearers — an elegant cross-domain mapping that's `[fit: reach]` is exactly what S must not stand on. This is the prompt-level analog of confidence-modulated debate — drift toward what is well-supported, not what is loudly claimed or prettily mapped.
+
+**Closure property.** Could a monk believe S at full conviction and argue from it as a position? If S is too abstract/meta/hedged to serve as input to the next round, recursion stalls.
+
+**Model update.** End with: "Before this dialectic, the assumption was X. The contradiction between A and B revealed Y. The updated model is Z, because..."
+
+### S failure modes (the classics)
+
+- "Use A sometimes and B sometimes" — division of labor, not sublation
+- "Combine the best of A and B" — compromise
+- "It depends on context" — surrender
+- Policy recommendations — not reconceptualization
+- **Analytical capture** — S adopts one monk's epistemological framework to reframe the other's claims. Test: does S translate one monk's language into the other's terms? If Monk A says "love" and S says "meta-cognitive capacity for empathetic attunement," S was captured by Monk B's epistemology. LLMs are *systematically* biased toward this — language-prediction engines operationalize things; when the dialectic is about whether operationalization is sufficient, the orchestrator is the worst possible judge.
+- **Level reduction** — if a monk made a categorically different *kind* of claim (not different degree), does S engage at its level? A synthesis that translates Level 4 claims into Level 3 terms *enacts the error the dialectic was about.* Test: would the higher-level monk say "you've done exactly what I warned against"?
+
+## 5.3 Candidate J — Sustained Juxtaposition (Adorno / Derrida / Koestler)
+
+**Fires when:** 4.2.5 surfaced a disguised shared interest both positions tacitly need to stay true, OR Lens B (synthesis residue) found atomic parts that S will drop or smooth over.
+
+**Posture:** Refuse unification. The contradiction is more productive held open than resolved. Adorno: the genuine object lives in the gap between concept and instance; a completed synthesis is a suspect synthesis. Koestler: bisociation's third form is the aesthetic "Ah" — two matrices held in sustained juxtaposition without fusion.
+
+### J must
+
+1. **Name what both positions tacitly share** that neither can examine (from 4.2.5 position-protection, or from the shared assumption in 4.2). J's central move is refusing to let this shared interest win by default.
+2. **Name the specific atomic parts** S would drop (from Lens B) and show why they matter.
+3. **Articulate what the juxtaposition reveals** that neither pole alone sees and that S would smooth over. "Both are partly right" is not enough — describe what becomes visible *only* when both are held without resolution.
+4. **Preserve local sovereignty.** If the domain has natural zones (different contexts, scales, stakeholders), name where each monk's logic reigns locally and why the global unification is what's wrong.
+5. **Name the hidden cost of synthesizing.** What gets lost if the contradiction is resolved? Often this is the real answer.
+
+### J internal standards
+
+- **Not-same-as-S test.** Re-read the S draft (after J is complete). Is J genuinely a different candidate, or does it collapse into "S with more humility"? If the latter, J hasn't earned its slot — rewrite or drop.
+- **Refused-interest citation.** Cite the exact passage in each monk where the disguised shared interest is visible. J's refusal is what makes it structurally distinct from S.
+- **Closure property.** Can a monk believe "the tension between X and Y is irreducible, and here's what that reveals"? Juxtaposition has closure when it can itself serve as a position in the next round.
+
+### J failure modes
+
+- "Both are right in their own way" — that's surrender, not juxtaposition. J must name what the juxtaposition *reveals* that unification hides.
+- Resolving the tension under a different name. If the zones-have-local-logics candidate resolves into "here's the meta-principle that tells you which zone applies," that's S with extra steps.
+- Performative irresolution. Refusing to resolve without saying what the refusal reveals is empty.
+
+## 5.4 Candidate G — Ground Condition (Lens A / Schumacher)
+
+**Fires when:** Lens A (briefing residue) caught a concrete material fact or stated preference neither monk operated on, OR the domain plausibly has a level-shift resolution (an orthogonal factor at a different level of being: love, attention, character, relationship, a physical constraint, a ground condition).
+
+**Posture:** The resolution lives at a different level than the debate. Schumacher (Guide for the Perplexed): problems solvable by intelligence (Level 3) vs. problems requiring wisdom/love (Level 4); a ground-level factor can make a Level-3 debate moot. The dialectic's natural move is horizontal differentiation within the debate's axis; G refuses that plane.
+
+### G must
+
+1. **Name the specific ground condition** — the material fact, higher-level factor, or orthogonal variable that dissolves the debate. Be concrete: "the yard has no back door" or "a teacher who loves their students makes most methods work," not "context matters."
+2. **Show that the debate is operating at the wrong level.** Both monks are arguing on axis X; G says the load-bearing variable is Y, which is not on axis X at all.
+3. **Cite the briefing line or domain fact** the ground condition rests on (from Lens A), or name the higher-level factor and the tradition that takes it seriously.
+4. **Explain why the debate persists despite the ground condition.** Usually because the ground condition isn't legible to the debate's methods, or because naming it sounds evasive to participants who've staked their positions.
+
+### G internal standards
+
+- **Not-the-horizontal-embedding test.** G must not be S with a new top-level concept bolted on. Test: does G's ground condition sit on the *same axis* as the original debate (stronger-A, stronger-B, a blend)? If yes, it's horizontal, not vertical. G only earns its slot if the ground condition is genuinely on a different axis.
+- **The level-reduction risk.** If G's ground condition itself resists analytical treatment (love, attention, quality), G must describe it on its own terms, not operationalize it. Operationalizing a Level-4 factor to make it legible to Level-3 methods is the same failure as analytical capture in S.
+- **Concrete enough to act on.** If G's ground condition is so general it applies to any debate, it isn't a ground condition — it's a platitude.
+
+### G failure modes
+
+- "It depends on [meta-factor]" — surrender rebranded as ground condition.
+- Naming a ground condition that's really a synthesis (e.g., "the real variable is how well A and B integrate") — that's S.
+- Ground conditions that are secretly one monk's position dressed up as transcendent.
+
+## 5.5 Candidate F — Framing Dissolution (Foucault)
+
+**Fires when:** Lens C surfaced a fossil framing serving a specific constituency that isn't the actual decision-maker.
+
+**Posture:** The debate doesn't need resolving; it needs stepping out of. The current binary is a fossil of an earlier professional conflict in an adjacent field, persisting because specific constituencies (magazines, disciplinary specialists, tech media, policy advocacy networks) have stakes in the debate remaining stateable in *these* terms. The actual decision-maker (this family, this developer, this historian) faces a different-shaped decision entirely.
+
+### F must
+
+1. **Name the fossil.** Which earlier conflict, era, or discursive formation birthed this binary? When?
+2. **Name the constituency the framing serves.** Magazines? Disciplinary specialists? A vendor ecosystem? Policy advocates? Be specific.
+3. **Contrast with the actual decision-maker's situation.** What question are they actually facing? Usually it's not the framed binary but something the framed binary obscures.
+4. **Propose the reframed question.** Not "the synthesis" — the *different question* the decision-maker should be asking.
+
+### F internal standards
+
+- **The genealogy must be specific.** "The binary comes from [historical period]" with a named moment, field, or conflict. Vague framings ("this is just capitalism/modernity talking") are not genealogy; they're noise.
+- **The constituency must be nameable.** If the answer is "everyone," F hasn't found the fossil — it's describing a universal condition, not a contingent framing.
+- **The reframed question must be concrete.** Must be something the user could actually think about or act on, not "rise above the binary."
+
+### F failure modes
+
+- Framing-as-therapy. "Just stop thinking about it this way" isn't F — F has to produce the different-shaped question.
+- Conspiracy-lite. Naming a shadowy "they" without specific constituency or mechanism. Foucault's actual practice is genealogical and concrete.
+- Dissolving the framing but landing on S. If F ends with "and the real answer is [unified concept]," it's S with a preamble.
+
+## 5.6 Candidate U — Undecidable-Centered (Derrida)
+
+**Fires when:** Lens D caught a word both monks use prominently with opposite loadings — a term that appears on both sides but means incompatible things.
+
+**Posture:** The contradiction is the word. The real object of dispute isn't the binary — it's the term both sides claim. Derrida's undecidables are not third terms; they are terms that refuse the binary. U's move is to center the word itself as the thing at stake.
+
+### U must
+
+1. **Name the word.** Cite the exact passage in each monk where the opposite loading is visible.
+2. **Map both loadings.** What is Monk A claiming the word means? What is Monk B claiming? Where do the loadings overlap, and where do they diverge irreconcilably?
+3. **Refuse to pick a loading.** U's move is specifically *not* adjudicating. If U ends with "and the correct meaning of the word is X," it has collapsed to S.
+4. **Articulate what the undecidability does.** Which decisions become clearer once you see that the word is doing contradictory work? Sometimes the undecidability is the whole finding — naming it precisely is the output.
+
+### U internal standards
+
+- **The word must be specific.** "Engagement," "scale," "quality," "freedom," "design." If U is operating on a concept-cluster rather than a single term, it's probably really F or G.
+- **Both loadings must be cited.** One passage per monk, minimum, showing the opposite usages. Uncited undecidables are orchestrator confabulation.
+- **No resolution.** The test that U is genuine: a reader finishes U and is *less* sure which meaning is correct, not more. If U makes the word more decidable, it has failed.
+
+### U failure modes
+
+- Semantic hand-wringing. "Words are slippery" is not U — U names the specific term and what its opposite loadings reveal.
+- Finding an undecidable that is really two different words. If A and B use "engagement" to mean different things because they're talking about different referents, that's disambiguation, not undecidability. U requires the *same* referent being loaded oppositely.
+- Collapsing U into "and therefore we need a new word" — that's S.
+
+## 5.7 Save and Present the Palette
+
+**Save each candidate** to `round_N_candidate_[S|J|G|F|U].md`. Save the full Phase 4 determinate negation to `round_N_determinate_negation.md` (already done). Do NOT save a single `round_N_sublation.md` — there is no single sublation.
+
+**Present the palette to the user** as a structural summary. For each candidate that was drafted, give:
+- The candidate's **central move** in 2-3 sentences
+- The **lens that earned it** (why this candidate is in the palette)
+- The **new contradiction** the candidate generates (if any — not all candidates need to be fertile in the same way)
+
+Format the presentation so the user can see the palette side-by-side. **Do not rank. Do not recommend. Do not say "I think S is strongest."** The user is the judge; the orchestrator's job is to make each candidate as strong as it can be on its own terms.
+
+Conclude with:
+
+> Here are [N] structurally-distinct candidates for where this dialectic lands. Each has a different posture — [S/J/G/F/U] — and they're not meant to converge. Pick one, combine two, or tell me which ones to send through validation in Phase 6. Or say "none of these land — go back to Phase 4 and reopen the decomposition."
+>
+> Remember: your judgment is the point here. The monks are belief-committed and the orchestrator has spent a lot of token budget on this decomposition, but the question of which candidate fits your actual situation is one only you can answer.
+
+**Anti-sycophancy when receiving feedback:** When the user picks a candidate or rejects the whole palette, do not capitulate or celebrate. If the user picks S, it is not because S was "the right answer" — it is because it fit their situation. If the user picks J and later says "actually I think S is closer," that is the dialectic working. If the user rejects the palette, examine *which specific move* in each candidate failed — don't just promise to try harder. If the user provides a new framework or insight, it enters the decomposition as material to be stress-tested in the next round, not as the answer the candidates should have reached.
+
+## 5.8 Model Selection
+
+Generate candidates with the strongest available model with extended thinking. Each candidate needs maximum reasoning capacity — especially J (which must refuse the gravitational pull toward synthesis), G (which must resist horizontal embedding), and U (which must refuse to resolve). S is the default posture and easiest; the non-S candidates are where the orchestrator needs the most lift.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase6-stage-a-monk-validation.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase6-stage-a-monk-validation.md
@@ -1,0 +1,144 @@
+# Phase 6 — Stage A: Monk Validation (6.2)
+
+*For each candidate the user selected (6.0), send the candidate-type-specific prompt below to both monks. Apply only the sub-section matching the candidate you're validating.*
+
+## 6.2 Monk Validation — Per Candidate
+
+For each candidate under validation, send to **both monks** (each in their own session, if session resumption is available). The monk validation prompt is candidate-type-specific.
+
+### 6.2.S Validating Candidate S (Synthesis)
+
+Classical Aufhebung validation. Send to each monk:
+
+```
+You argued passionately for [POSITION]. [Resume session OR: here is a summary
+of your argument: ...]
+
+A dialectician analyzed the structural contradiction between your position and
+your opponent's, and proposed a SYNTHESIS candidate:
+
+[CONDENSED SUMMARY OF S — what's cancelled, preserved, elevated, the concrete proposal]
+
+Evaluate honestly from your committed position:
+
+1. Does this synthesis PRESERVE your core insight? What specifically does it get right?
+2. Does it reveal a genuine limitation in your position? What were you missing?
+3. Do you feel ELEVATED or DEFEATED? "Elevated" = "my position is a partial truth
+   within a larger truth I couldn't have reached alone." "Defeated" = "my position
+   was dismissed or diluted." Be honest.
+4. What's wrong with this synthesis? Where is it weak, evasive, or compromise?
+5. DEFEASIBILITY: What single piece of evidence or argument, if true, would force
+   you to abandon even your ELEVATED position?
+
+Do NOT be agreeable. If the synthesis is compromise dressed up, say so.
+```
+
+### 6.2.J Validating Candidate J (Juxtaposition)
+
+The monks are *not* supposed to feel elevated here — J's whole move is refusing the unification that would elevate them. Validation checks whether the juxtaposition actually reveals something.
+
+```
+You argued passionately for [POSITION]. [Resume session OR: summary...]
+
+A dialectician proposed a JUXTAPOSITION candidate — NOT a synthesis. It refuses
+to resolve the contradiction between your position and your opponent's. Instead,
+it claims that holding both open reveals something neither of you could see alone,
+and that synthesizing would smooth over something important.
+
+[CONDENSED SUMMARY OF J — the refused shared interest, what the juxtaposition
+reveals, the atomic parts S would drop]
+
+Evaluate honestly:
+
+1. Does the juxtaposition name a genuine shared interest both of us were protecting?
+   Or is the "shared interest" claim overreach?
+2. What the juxtaposition claims gets LOST in synthesis — does it really get lost?
+   Or could a good synthesis preserve it?
+3. Does holding both positions open reveal what the juxtaposition claims it reveals?
+   Or is the "reveal" just restating the contradiction?
+4. Is this juxtaposition PRODUCTIVE or EVASIVE? "Productive" = refusing resolution
+   makes something visible that would otherwise be hidden. "Evasive" = refusing
+   resolution is just intellectual cowardice dressed up as Adorno.
+5. What's the cost if the user takes the juxtaposition seriously and doesn't resolve?
+   What decisions does it delay or obscure?
+```
+
+### 6.2.G Validating Candidate G (Ground Condition)
+
+```
+You argued passionately for [POSITION]. [Resume session OR: summary...]
+
+A dialectician proposed a GROUND CONDITION candidate — NOT a synthesis. It claims
+your debate is operating on the wrong axis entirely. The real load-bearing variable
+lives at a different level than either of your positions engage.
+
+[CONDENSED SUMMARY OF G — the named ground condition, why the debate misses it]
+
+Evaluate honestly:
+
+1. Does the ground condition G names actually dissolve the debate, or does it just
+   reframe one side's advantage?
+2. Is the ground condition on a GENUINELY DIFFERENT axis, or is it a meta-level
+   version of one of our positions?
+3. If the ground condition is real, why were we both missing it? What does that say
+   about the frame we were operating in?
+4. Does G operationalize something you were claiming resists operationalization?
+   If it does, G has done the reductive move you were warning against.
+5. What would it look like for someone to act on G's ground condition? Is that
+   concrete enough to try, or is it a platitude?
+```
+
+### 6.2.F Validating Candidate F (Framing Dissolution)
+
+```
+You argued passionately for [POSITION]. [Resume session OR: summary...]
+
+A dialectician proposed a FRAMING DISSOLUTION candidate — NOT a synthesis. It
+claims the binary you and your opponent were debating is a fossil of an earlier
+conflict, serving a specific constituency that isn't the actual decision-maker.
+
+[CONDENSED SUMMARY OF F — the fossil origin, the constituency served, the
+reframed question]
+
+Evaluate honestly:
+
+1. Is the genealogy F claims actually correct? Does this binary really come from
+   the era/conflict F names?
+2. Is the constituency F names actually the one served? Or is F scapegoating an
+   easy target?
+3. Does the reframed question F proposes illuminate the actual decision, or does
+   it replace one fossil with another?
+4. Even if the framing is a fossil, does the question it encodes still matter?
+   Some fossils are fossils because the question IS still live.
+5. What's the risk of accepting F's dissolution? What gets lost if we stop asking
+   the binary question entirely?
+```
+
+### 6.2.U Validating Candidate U (Undecidable)
+
+```
+You argued passionately for [POSITION]. [Resume session OR: summary...]
+
+A dialectician proposed an UNDECIDABLE-CENTERED candidate — NOT a synthesis. It
+claims the real object of dispute is a single word you and your opponent both use
+with opposite meanings.
+
+[CONDENSED SUMMARY OF U — the named word, both loadings, cited passages]
+
+Evaluate honestly:
+
+1. Do you recognize the loading U attributes to you? Is that what you meant by
+   the word?
+2. Is your opponent's loading opposite in the way U claims, or is it just
+   different in some other axis?
+3. Does the undecidability U names explain something about why our debate felt
+   harder than it should have — OR is it noise?
+4. Would resolving the word's meaning resolve the debate? Or would it just move
+   the contradiction to a different term?
+5. Is U refusing resolution because resolution is genuinely impossible here, or
+   because the dialectician didn't try hard enough?
+```
+
+---
+
+**Before moving on:** write each candidate's monk-validation output to `round_N_validation_<candidate>.md` (e.g. `round_N_validation_S.md`). Then read `reference/phase6-stage-b-hostile-auditor.md`.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase6-stage-b-hostile-auditor.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase6-stage-b-hostile-auditor.md
@@ -1,0 +1,157 @@
+# Phase 6 — Stage B: Hostile Auditor (6.3)
+
+*For each candidate under validation, spawn one hostile auditor using the candidate-type-specific prompt below. Apply only the sub-section matching the candidate you're auditing.*
+
+## 6.3 Hostile Auditor — Per Candidate
+
+Spawn one hostile auditor per candidate under validation. Each auditor reads **only** the monk essays and the single candidate it's auditing — NOT the orchestrator's Phase 4 analysis, NOT the other candidates.
+
+**Critical:** do NOT give the auditor sight of sibling candidates. A J-auditor who reads S will drift toward "why isn't J more synthetic?" — which is the wrong question. Each auditor attacks its candidate on its candidate's own internal standard.
+
+**Give the auditor domain context** — 2-3 sentences about how the domain actually works (actors, mechanics, current state). This prevents false-premise critiques.
+
+### 6.3.S Auditor for S
+
+Use the existing hostile-auditor prompt from prior versions of this skill, including:
+- Compare against the status quo, not the ideal
+- Attack the synthesis, not the positions
+- Find hidden shared assumptions
+- Undercutting > self-defeating > rebutting defeaters
+- Prospective hindsight
+- Compromise detection
+- Reversibility check (Boyd)
+- Closure check
+- Propose the harder contradiction
+- No generic skeptic moves; be specific to this synthesis and domain
+
+### 6.3.J Auditor for J
+
+```
+You are a hostile auditor of a JUXTAPOSITION candidate. Your job is to be correct,
+not fair.
+
+DOMAIN CONTEXT: [2-3 sentences]
+
+Read the two monk essays and the juxtaposition candidate. Your mandate:
+
+1. IS THE REFUSED SHARED INTEREST REAL? J claims both positions tacitly need
+   something to stay true. Cite the passages J cites and check: does the citation
+   support the claim, or is J making it up?
+2. WOULD A GOOD SYNTHESIS ABSORB J'S RESIDUE? J claims S will smooth over specific
+   atomic parts. Is that really unavoidable, or is J erecting a straw synthesis?
+3. IS THE REVEAL GENUINE? J must articulate what juxtaposition reveals. Is the
+   "reveal" actually new information, or just restating the contradiction in different
+   words?
+4. EVASION CHECK: Is J refusing resolution because resolution is genuinely wrong
+   here, or because synthesizing is hard and refusing is easier?
+5. LOCAL SOVEREIGNTY CHECK: If J claims zones have locally-sovereign logics, is
+   there actually a boundary between zones? Or are the "zones" a convenient fiction
+   that dissolves on closer inspection?
+6. CLOSURE: Can a monk believe "the tension is irreducible and here's what that
+   reveals" at full conviction and argue from it? If J has no closure, it can't
+   serve as input to the next round.
+7. PROPOSE THE HARDER CONTRADICTION that J hides behind its irresolution.
+
+If J is genuinely strong, say so and stop. "I found no structural flaws; the
+juxtaposition earns its refusal" is a valid output.
+```
+
+### 6.3.G Auditor for G
+
+```
+You are a hostile auditor of a GROUND CONDITION candidate. Your job is to be
+correct, not fair.
+
+DOMAIN CONTEXT: [2-3 sentences]
+
+Read the two monk essays and the ground-condition candidate. Your mandate:
+
+1. IS THE GROUND CONDITION ACTUALLY ORTHOGONAL? G claims the real variable is on
+   a different axis than the debate. Is it genuinely different, or is it the same
+   axis with a new label?
+2. IS IT CONCRETE? G must name a specific material fact or level-shift factor.
+   Vague ground conditions ("context matters," "it depends on culture") are not
+   ground conditions.
+3. LEVEL-REDUCTION CHECK: If G invokes a higher-level factor (love, wisdom,
+   attention), does G operationalize it in a way that reduces it to the lower
+   level? If so, G enacts the same error S is vulnerable to.
+4. IS THE GROUND CONDITION LOAD-BEARING? G claims the debate becomes moot once
+   the ground condition is named. Test: is the debate really moot, or is the
+   ground condition merely a tiebreaker that leaves the debate live?
+5. WHY WAS IT MISSED? G must explain why both monks overlooked the ground
+   condition. If the explanation is "they weren't smart enough," G is probably
+   confabulating — both monks are pushed to full conviction specifically to
+   avoid that failure mode.
+6. ACTION TEST: Is G concrete enough to act on? If following G's ground condition
+   in practice is impossible or trivial, G is a platitude.
+7. PROPOSE THE HARDER CONTRADICTION G is sidestepping.
+
+If G is genuinely strong, say so.
+```
+
+### 6.3.F Auditor for F
+
+```
+You are a hostile auditor of a FRAMING DISSOLUTION candidate. Your job is to be
+correct, not fair.
+
+DOMAIN CONTEXT: [2-3 sentences]
+
+Read the two monk essays and the framing-dissolution candidate. Your mandate:
+
+1. IS THE GENEALOGY CORRECT? F claims the binary comes from a specific era/
+   conflict/field. Check: does the historical claim hold up, or is F constructing
+   a convenient fossil?
+2. IS THE CONSTITUENCY REAL AND LOAD-BEARING? F claims a specific constituency
+   benefits from the debate persisting. Is that constituency actually the one
+   that keeps the debate alive, or is F scapegoating an easy target?
+3. IS THE REFRAMED QUESTION BETTER? F proposes a different-shaped question. Is
+   the new question actually more illuminating, or is it just a different
+   framing with its own hidden assumptions?
+4. FOSSIL-AS-LIVE-QUESTION: Some questions persist because they're still live,
+   not because a constituency is keeping them alive. Is F mistaking a live
+   question for a fossil?
+5. CONSPIRACY-LITE CHECK: Is F naming a specific constituency with a specific
+   mechanism, or is it hand-waving about "the system"? If the latter, F is
+   not genealogy; it's noise.
+6. DISSOLVE-TO-SYNTHESIS CHECK: Does F end with a unified reframed answer, or
+   does it genuinely step out of the frame? If F dissolves into S, it's not F.
+7. PROPOSE THE HARDER CONTRADICTION the fossil framing was hiding.
+
+If F is genuinely strong, say so.
+```
+
+### 6.3.U Auditor for U
+
+```
+You are a hostile auditor of an UNDECIDABLE-CENTERED candidate. Your job is to be
+correct, not fair.
+
+DOMAIN CONTEXT: [2-3 sentences]
+
+Read the two monk essays and the undecidable candidate. Your mandate:
+
+1. IS THE WORD ACTUALLY USED OPPOSITELY? U cites passages from each monk. Do
+   those passages actually load the word oppositely, or is U finding contradiction
+   where there's just ambiguity?
+2. SAME REFERENT CHECK: U requires both monks to use the same word about the
+   same referent with opposite loadings. If the monks are using the word about
+   different referents, that's disambiguation, not undecidability.
+3. DOES UNDECIDABILITY MATTER? U claims the word is the real object of dispute.
+   Test: would settling the word settle the debate? If yes, the debate wasn't
+   really about the word. If no, U has found something structural.
+4. REFUSAL-IS-GENUINE CHECK: U must refuse to resolve. Did U secretly resolve
+   by privileging one loading? Re-read U looking for hidden adjudication.
+5. NEW-WORD-ESCAPE CHECK: Does U collapse into "and therefore we need a new
+   word"? That's S, not U.
+6. CLOSURE: Can a monk believe "the word is undecidable and here's what that
+   does to our decisions" at full conviction? If U has no closure, it's hand-
+   wringing.
+7. PROPOSE THE HARDER CONTRADICTION around the undecidable term.
+
+If U is genuinely strong, say so.
+```
+
+---
+
+**Before moving on:** append each auditor's output to the matching `round_N_validation_<candidate>.md`. Then read `reference/phase6-stage-c-interpret-refine.md`.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase6-stage-c-interpret-refine.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase6-stage-c-interpret-refine.md
@@ -1,0 +1,61 @@
+# Phase 6 — Stage C: Interpret + Refine (6.4, 6.5, 6.6)
+
+*With monk validations (Stage A) and auditor reports (Stage B) in hand, interpret each candidate on its own terms, then help the user refine the palette. Do not cross-rank candidates.*
+
+## 6.4 Interpreting the Results — Per Candidate
+
+Each candidate's validation is interpreted on its own terms. Do NOT cross-rank candidates.
+
+### S interpretation
+- **Both monks feel elevated:** S is valid. Belief was transformed, not defeated.
+- **One monk feels defeated:** S is biased toward the other side. Revise S or drop it from the palette.
+- **Both monks feel defeated:** S killed both beliefs without replacing. Probably compromise. Drop S or reopen Phase 4 for this candidate.
+- **Auditor flags compromise-as-transcendence:** Revise S.
+- **Auditor proposes harder contradiction:** This is a high-value Phase 7 recursion target.
+
+### J interpretation
+- **Both monks say the juxtaposition is PRODUCTIVE:** J is valid.
+- **Either monk says it's EVASIVE:** Check whether the monk's critique is structural or is itself protecting the shared interest J surfaced. If the latter, the critique is evidence J is right.
+- **Auditor says the "reveal" is just restating the contradiction:** Revise J or drop.
+- **Auditor says zones are a convenient fiction:** If J relies on local sovereignty, this may be fatal. Re-examine.
+
+### G interpretation
+- **Both monks say the ground condition dissolves the debate:** G is valid.
+- **Either monk says G operationalizes a higher-level factor as a lower-level mechanism:** G has enacted level-reduction. Drop or revise.
+- **Either monk says G is on the same axis in disguise:** G hasn't earned its slot.
+- **Auditor says "why was it missed" explanation is confabulation:** Check carefully — this is a common G failure mode.
+
+### F interpretation
+- **Both monks say the genealogy and reframed question are correct:** F is valid.
+- **Either monk challenges the historical claim:** Check the claim. If F's genealogy is sloppy, F fails.
+- **Auditor says the constituency is scapegoat, not load-bearing:** Revise or drop.
+- **Auditor says the refocused question has its own fossil:** This is a Phase 7 recursion target — F exposed one frame, the recursion may need to expose the next.
+
+### U interpretation
+- **Both monks recognize the opposite loadings:** U has identified something real.
+- **Either monk says "we're using the word about different referents":** U is disambiguation, not undecidability. Drop or reframe.
+- **Auditor says U secretly privileges one loading:** Revise to make the refusal-to-resolve genuine.
+- **U survives intact:** The undecidable is itself the finding for this round. It enters Phase 7 as the object, not as a problem to resolve.
+
+## 6.5 Refining the Palette
+
+After validation, the user picks among:
+- **Accept a single candidate** and proceed to Phase 7 with that candidate as the round's output
+- **Combine two candidates** — explicitly name how they combine (e.g., "S for the central move, J for what S drops") rather than collapsing J into S
+- **Drop all candidates** and reopen Phase 4 — the decomposition didn't produce a candidate that fits
+- **Hold the palette open** — declare the round's output to be the palette itself; Phase 7 recursion engages whichever candidate the user finds most productive next
+
+**Write the full validation and auditor output to files** — one per candidate (e.g., `round_N_validation_S.md`, `round_N_validation_J.md`).
+
+**Do not dump all feedback on the user.** For each candidate that survived validation, present:
+- A 2-3 sentence summary of what the monks and auditor said
+- The ONE concrete improvement (if any) most worth making
+
+Then ask the user, per surviving candidate: "Incorporate this improvement? Or take the candidate as-is?" — **one at a time**, waiting for response between candidates. Even numbered sequentially, a wall of improvements across 3 candidates overwhelms and the user skims.
+
+## 6.6 Anti-Sycophancy in Validation and Refinement
+
+- When the user picks a candidate, do not celebrate. The pick is the user's judgment about fit; it's not a verdict on correctness.
+- When the user rejects a candidate that the monks and auditor approved, do not capitulate. Say: "the monks and auditor both found this structurally sound — [specific points]. Are you sure the issue isn't [specific alternative reading]?" The user's judgment takes priority, but fold only after the case has been made.
+- When the user proposes a new framework during refinement, it enters Phase 7 as decomposition material, NOT as the answer Phase 5 should have produced.
+- Do NOT track the user's preferences across candidates and use them to bias the next round. The user is belief-free; treat each round's candidate selection as local to that round.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase6-validation.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase6-validation.md
@@ -1,0 +1,36 @@
+# Phase 6: Validation of the Palette
+
+Phase 6 validates the palette from Phase 5. The user selects which candidate(s) to validate — typically one or two, not all. Each selected candidate is validated **on its own terms** against its own internal standard, by the monks and by a hostile auditor.
+
+**No tournament, no winner, no Borda count.** The user judges which candidate fits their situation. The monks and auditor produce structural critiques per candidate, not rankings across candidates.
+
+**Critical ABS insight (still applies to S):** The monks don't *stop believing* after validation. A defeated monk has dropped its belief load — belief fell on the floor rather than being sublated. A properly elevated monk *believes more*. For non-S candidates (J/G/F/U), "elevation" means something different — see each candidate's validation prompt below.
+
+## This phase is staged — read one stage file at a time
+
+Phase 6 is long because each working step carries a full prompt for every candidate type (S/J/G/F/U). The setup below (6.0, 6.1) runs once, up front. The three working stages then repeat for each candidate under validation. **Do not read the stage files all at once** — for each stage: read the stage file, do its work, **write its output to file** (`round_N_validation_<candidate>.md`), then read the next stage.
+
+| Stage | File | Sections | The move |
+|---|---|---|---|
+| A | `reference/phase6-stage-a-monk-validation.md` | 6.2 (S/J/G/F/U) | The monks validate each candidate |
+| B | `reference/phase6-stage-b-hostile-auditor.md` | 6.3 (S/J/G/F/U) | A hostile auditor attacks each candidate |
+| C | `reference/phase6-stage-c-interpret-refine.md` | 6.4, 6.5, 6.6 | Interpret per candidate, refine, present |
+
+When validating a single candidate, you only use that candidate's sub-section within each stage (e.g. 6.2.S and 6.3.S) — read the stage file but apply only the relevant variant.
+
+## 6.0 Select Candidates to Validate
+
+The user picks which candidate(s) from the palette go into validation. Common patterns:
+- **One candidate** the user finds most promising — validate it alone.
+- **Two candidates** that feel like real alternatives — validate both and see which survives more intact.
+- **All candidates** if the user wants maximum friction before deciding (expensive; rarely needed).
+
+If the user defers the choice, validate S plus the non-S candidate that fired on the strongest lens signal (usually J if position-protection fired, otherwise whichever lens had the highest-signal finding).
+
+## 6.1 Model Selection
+
+Use the strongest available model with extended thinking for all validation agents. Validation is subtle — the monks must reason about whether their core insight was genuinely preserved or quietly destroyed; the auditor's value comes from catching what everyone else missed. Cost is low (reading short-to-medium essays), leverage is high.
+
+---
+
+Once the user has selected candidates (6.0) and you've set the model (6.1), read `reference/phase6-stage-a-monk-validation.md` and begin.

--- a/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase7-recursion.md
+++ b/chezmoi/dot_agents/skills/hegelian-dialectic-skill/reference/phase7-recursion.md
@@ -1,0 +1,95 @@
+# Phase 7: Recursion — Where the Real Value Lives
+
+**Recursion is not optional cleanup. It is the engine of the skill.** The first round produces a synthesis. The recursive rounds force that synthesis to confront its own limitations, generating increasingly powerful mental models. Each cycle compresses understanding upward. In test runs, a React/Vue dialectic went from "corporate lab vs. independent auteur" → "the Layer Thesis" → "co-evolutionary arms race." An institutional identity dialectic went from "enforcement vs. freedom" → "practice-based identity" → "nucleation as formation mechanism" → then surfaced a third-level tension that reframed everything. In both cases, the recursive rounds produced the most valuable insights.
+
+**When transitioning to recursion, tell the user:**
+
+> That was Round 1. Here's something important: **that round was the least insightful we'll get.** It was calibration — getting the broad shape of the tension on the table. Each subsequent round gets sharper, more specific to your actual situation, and more likely to surface something genuinely new. The process is like focusing a lens — each round tightens the resolution. Ready for Round 2?
+
+**The default should be to recurse at least once.** Only stop if:
+- The synthesis generated no significant new contradictions (rare if the sublation is genuine — a real Aufhebung is fertile)
+- The user explicitly wants to stop
+- The new contradictions are outside the scope of what the user cares about
+
+## Proposing Recursive Directions
+
+After Phase 6 validation, the orchestrator has rich material for identifying where the dialectic could go next. **The orchestrator proposes directions — the user chooses.** A genuine sublation is fertile: it typically generates multiple new contradictions, not just one. The dialectic *branches*.
+
+Sources for recursive contradictions:
+- **New contradictions identified in Phase 5** — every genuine sublation generates these
+- **Convergent critiques from validation agents** — when both agents independently identify the same weakness, that weakness IS a candidate contradiction
+- **The user's intervention** — often the most powerful source. The user sees something both agents and the orchestrator missed.
+- **Unresolved tensions the synthesis names but doesn't engage** — the synthesis may acknowledge a deeper problem without solving it
+
+**Be creative about what kinds of contradictions you propose.** They don't have to be two sides of the same question at a higher level. They can be:
+- A tension *within* the synthesis itself (the synthesis says X, but X requires Y, and Y conflicts with the synthesis's own premises)
+- A tension between the synthesis and the *domain's actual power structure* (the synthesis is intellectually right but doesn't engage how decisions actually get made)
+- A tension between what the synthesis recommends and what's actually feasible given constraints the first round abstracted away
+- A meta-tension about the *kind of answer* the dialectic produced (e.g., "our synthesis is a theory — but does the domain need a theory or a mechanism?")
+
+## Present a Menu, Not a Decision
+
+**YOU MUST DO THE IDEA BURST BEFORE PROPOSING DIRECTIONS.** This is the most commonly skipped step in the entire skill, and skipping it visibly degrades the quality of recursive directions. When the orchestrator jumps straight to "here are 2-3 directions," it proposes whatever's most obvious from the synthesis — which is almost always a safe, predictable next step rather than the genuinely fertile contradiction that would produce the best next round. The idea burst is what prevents this.
+
+**Do not skip this step. Do not abbreviate it. Do not combine it with direction-clustering.** Generate the burst first, read it, *then* cluster.
+
+Generate a **burst of 5-8 candidate concepts/directions** — not just contradictions but concrete mechanisms, architectural patterns, novel framings, and open vulnerabilities that the synthesis makes newly conceivable. Cast a wide net first: the value is in the *density* of the newly opened conceptual space. Include material from monk defeasibility responses (Phase 6, question 5), auditor output, and your own structural analysis. The burst should contain ideas that surprise you — if every item is predictable from the synthesis, you're not casting wide enough.
+
+Then **cluster the burst into 2-4 coherent directions**, each briefly described as a contradiction worth exploring. Several candidate concepts often point at the same underlying tension from different angles. For example:
+
+> The synthesis generated three fertile contradictions:
+> 1. **The formation problem:** The synthesis says identity should live in shared practice — but who forms the practitioners? (internal tension)
+> 2. **The authority problem:** The synthesis argues from historical theology, but decisions are made by prophetic authority — does this synthesis engage the actual power structure? (synthesis vs. domain reality)
+> 3. **The scalability problem:** Nucleation works for small communities — does it survive contact with a 30,000-student institution? (synthesis vs. feasibility)
+>
+> Which would you like to pursue? (Or we can queue multiple for successive rounds.)
+
+**The user may want to queue multiple directions.** A dialectic can branch — Round 2 pursues direction A, Round 3 pursues direction B (starting from the Round 2 synthesis), or Round 3 forks back to the Round 1 synthesis to pursue direction C independently. The orchestrator should track which contradictions have been explored and which are queued.
+
+**Write the queue to a file** (e.g., `dialectic_queue.md`) — a running list of proposed contradictions with their source round and status (explored, queued, deferred). This becomes a map of the dialectical territory: where you've been, where you could go, and what's still open. Present a concise summary of the directions to the user — the full queue is in the file.
+
+## Running Recursive Rounds
+
+Each recursive cycle follows Boyd's full cycle: the previous synthesis is a Structure that must be Unstructured (destructive deduction — shatter it into atomic parts, break the correspondence between the concept and its constituents) and Restructured (creative induction — find cross-domain connections to synthesize something new). Boyd proves this isn't just a good idea — the Second Law guarantees that any inward-oriented refinement of the existing synthesis will increase entropy. Recursive rounds often need **new research and fresh agents** because the system must open itself to outside material or face increasing mismatch.
+
+**New research in recursion is often essential.** Boyd's Gödelian argument applies directly: you cannot determine the consistency of a synthesis from within the same conceptual system that produced it — you must appeal to systems outside it. Each synthesis opens a new conceptual space that the original research didn't cover. In the 7-cycle agent identity dialectic, successive rounds pulled in Gödel's incompleteness theorem, Coasean transaction cost theory, jurisprudential concepts, witness obligation patterns, and N-of-M quorum systems — none of which were in the original research. The synthesis *created the space* for this new material to enter: the destructive deduction liberates parts that can now connect with material from outside the original domains, which is exactly Boyd's creative induction in action.
+
+When to research in recursion:
+- The new contradiction involves concepts, mechanisms, or domains that weren't in the original research
+- The Boydian decomposition (Phase 4.6) reveals that adjacent-domain material would enable cross-domain connections
+- An agent or the user identifies a specific factual or theoretical gap
+
+When research is unnecessary:
+- The recursive contradiction is a tension *within* the existing synthesis that can be argued from material already in play
+- The round is primarily about clarifying or sequencing, not reconceptualizing
+
+**Fresh agents are usually better than resumed sessions for recursion.** The recursive round is a *new* dialectic — the contradiction has shifted, the conceptual space has evolved. Agents carrying forward their full conviction from the previous round may be trapped in their original framing. Fresh agents given the accumulated context (prior essays, structural analysis, sublation, validation critiques) plus the new contradiction can engage the evolved question without legacy commitment to positions that have already been sublated. This also brings fresh perspectives — different reasoning paths, different analogies, different ways of committing to the new positions.
+
+**Practical guidance:**
+- **Re-read the relevant phase reference doc before executing it in Round 2+.** Context drift is the most common failure mode in later rounds — the orchestrator starts cutting corners on exactly the steps that matter most. Before each phase, read its reference doc fresh from `reference/phase{N}-*.md`.
+- **Pass all prior context** (both essays, structural analysis, sublation, validation critiques) to new agents as background
+- **Include targeted research directives** if the new contradiction opens new domains — 2-3 specific searches per agent, just as in Round 1
+- **Use 1000-1500 word essays** — the conceptual space is richer, agents can be tighter
+- **Validation can be abbreviated** — a quick check that both agents feel elevated, or skip if time-constrained
+- Recursive rounds are faster than Round 1 even with research (~2-3 min vs ~20 min) because agents have dense context and need only targeted searches, not broad domain surveys
+
+## Inward-Orientation Check
+
+Boyd proves that any closed system's inward-oriented refinement *necessarily* increases mismatch — the Second Law guarantees it. In the dialectic, this manifests when later rounds start feeling like *polish* rather than *destruction*. If the orchestrator is refining the existing synthesis rather than shattering it against a new contradiction, the system is closing.
+
+**Diagnostic:** Are you importing new material from outside the synthesis's conceptual domain in this round? Or are you rearranging material already in play? If the Boydian decomposition in this round uses only parts already present in the previous synthesis, you're operating inward. The synthesis will feel more polished but will be *less* true — entropy is increasing even though it looks neater.
+
+**This is not always a problem.** Sometimes you're trying to ship something, not endlessly shatter. Refinement rounds have their place — tightening a synthesis before presenting it, resolving ambiguities, making it actionable. The check is a diagnostic, not a prohibition. But if you're refining because you've run out of ideas for what to shatter it against, that's the entropy signal. Either inject new external material (Phase 4.5 lateral interventions) or stop — you've reached the current ceiling.
+
+## When to Stop
+
+The system gets richer not by converging on a final answer but by accumulating resolved contradictions that form increasingly nuanced understanding. Stop when:
+- The queued contradictions are becoming less productive (diminishing returns)
+- The latest synthesis surfaces a contradiction that requires fundamentally different expertise or information than you have access to
+- The user has what they need
+
+**But err on the side of one more round.** The marginal insight is often the most powerful — it's the insight that couldn't have been reached without the preceding rounds building up to it.
+
+When stopping, present the user with the **final state of the dialectic queue** — which contradictions were explored, which remain open, and which were deferred. This is a map of the intellectual territory: the resolved contradictions form the new understanding, and the open contradictions are starting points for future sessions.
+
+See **Worked Examples → Example 3** in the main SKILL.md for a 7-cycle dialectic showing how each round pulls in cross-domain material — Boyd's prediction in action.


### PR DESCRIPTION
## Summary

- Vendored [`KyleAMathews/hegelian-dialectic-skill`][skill].
- Updated the skills README inventory.

[skill]: https://github.com/KyleAMathews/hegelian-dialectic-skill

## Impact

After Chezmoi applies this source tree, the skill is available under `~/.agents/skills/hegelian-dialectic-skill` for global agent use.

## Validation

- `diff -qr /private/tmp/hegelian-dialectic-skill-src.zM1KDE/extracted chezmoi/dot_agents/skills/hegelian-dialectic-skill`
- `scripts/agent-skills/scan.sh chezmoi/dot_agents/skills/hegelian-dialectic-skill` could not run because `skillspector` is not installed locally.

Upstream source: `KyleAMathews/hegelian-dialectic-skill@435b70249462d2908346cd00ede3288efaf828ba`.