### PR TITLE
fix: upgrade update.sh script

### DIFF
--- a/chezmoi/dot_config/zsh/custom.zsh
+++ b/chezmoi/dot_config/zsh/custom.zsh
@@ -28,6 +28,9 @@ export EDITOR="vim"
 # Initialize mise FIRST so its PATH entries come before Nix's
 eval "$(mise activate zsh)"
 
+# Load OrbStack shell integration when OrbStack is installed.
+source ~/.orbstack/shell/init.zsh 2>/dev/null || :
+
 # Fix PATH for nix-darwin (macOS path_helper overrides /etc/zshenv)
 # Add Nix paths AFTER mise so mise tools take precedence
 [[ ":$PATH:" != *":/etc/profiles/per-user/$USER/bin:"* ]] && export PATH="$PATH:/etc/profiles/per-user/$USER/bin"

--- a/home-manager/flake.lock
+++ b/home-manager/flake.lock
@@ -36,10 +36,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-mise": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-mise": "nixpkgs-mise"
       }
     }
   },

--- a/home-manager/flake.nix
+++ b/home-manager/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     # Specify the source of Home Manager and Nixpkgs.
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-mise.url = "github:NixOS/nixpkgs/3e41b24abd260e8f71dbe2f5737d24122f972158";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -11,7 +12,7 @@
   };
 
   outputs =
-    { nixpkgs, home-manager, ... }:
+    { nixpkgs, nixpkgs-mise, home-manager, ... }:
     let
       system = "aarch64-darwin";
       pkgs = import nixpkgs {
@@ -20,10 +21,14 @@
           "1password-cli"
         ];
       };
+      misePkgs = import nixpkgs-mise { inherit system; };
 
       # Helper function to create a home-manager configuration for a specific user
       mkHomeConfig = username: home-manager.lib.homeManagerConfiguration {
         inherit pkgs;
+        extraSpecialArgs = {
+          misePackage = misePkgs.mise;
+        };
 
         # Specify your home configuration modules here, for example,
         # the path to your home.nix.

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, misePackage ? pkgs.mise, ... }:
 
 {
   # Home Manager needs a bit of information about you and the paths it should
@@ -23,7 +23,7 @@
     chezmoi  # Must be in Nix - applies mise.toml config before mise install runs
     curl     # Must be in Nix - fetches agent skills before mise install runs
     jq       # Must be in Nix - reads skills-lock.json before mise install runs
-    mise     # Must be in Nix - installs other dev tools
+    misePackage  # Must be in Nix - installs other dev tools
 
     # System packages (not available or not suitable for Mise)
     cloudflared

--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778427648,
-        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.11",
+        "ref": "6.0.1",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779213149,
-        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
+        "lastModified": 1782233665,
+        "narHash": "sha256-h/xOtrByoA/Ak1lWHn0O1lVZz4qWYbwOSLQ8YSwQO0I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
+        "rev": "062581938b4a378a82dfbb294b494808157153a1",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1779283011,
-        "narHash": "sha256-t+yoQDd9lqfulhhtfWurFy8vntSD4/ygLo2NvJWCdXI=",
+        "lastModified": 1782245668,
+        "narHash": "sha256-M1lnkZnDMI4x6GZY9vqepv9J0ac7z+wWGZUZN2CerTg=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "2ea54578de93d08d080ee90cb47ebaa57ca92f90",
+        "rev": "c4bec866bf9d27854e318686dd6a34bd274addf8",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1779283693,
-        "narHash": "sha256-JatKjr+HttK1ZyftjthqmxZ5KQLt4kxNB/jxndL8oDw=",
+        "lastModified": 1782244635,
+        "narHash": "sha256-Nc9EE/PkCWdE0OI+97T361Ztatu7FoyvRyYwlCNHk5E=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "269cbb28ce5bd15bafc320bbafcf2c8942e1f618",
+        "rev": "6e3fd1a03ce2c52934f7b8c138357dc79fd60810",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     "homebrew-replicate": {
       "flake": false,
       "locked": {
-        "lastModified": 1779231794,
-        "narHash": "sha256-Cr/vmprp4Aj4zV5RRqqg4h25CsFn8GeDKlkmSSkd4Ic=",
+        "lastModified": 1781643596,
+        "narHash": "sha256-re/LEZuzdQCiCMnovMuEp/76bXe8HWTfawnjWuv5r1Q=",
         "owner": "replicate",
         "repo": "homebrew-tap",
-        "rev": "6df631f1673c4c7464b45417883c4986f26d7dc7",
+        "rev": "43df26d7583840f37b0cbe2af66f8f2822530240",
         "type": "github"
       },
       "original": {
@@ -92,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1778851564,
-        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
+        "lastModified": 1781389246,
+        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
+        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1782118813,
+        "narHash": "sha256-BnbXO5s5EhV89lLXMAGCzPdEN5a6vNqvMk71obeTEUw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "b3c092d3c36d91e2f61f3dfb39a159f180a56659",
         "type": "github"
       },
       "original": {

--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -139,6 +139,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-mise": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
@@ -147,7 +163,8 @@
         "homebrew-replicate": "homebrew-replicate",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-mise": "nixpkgs-mise"
       }
     }
   },

--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-mise.url = "github:NixOS/nixpkgs/3e41b24abd260e8f71dbe2f5737d24122f972158";
     
     nix-darwin = {
       url = "github:LnL7/nix-darwin";
@@ -33,8 +34,11 @@
     };
   };
 
-  outputs = { self, nixpkgs, nix-darwin, home-manager, nix-homebrew, homebrew-core, homebrew-cask, homebrew-replicate }:
+  outputs = { self, nixpkgs, nixpkgs-mise, nix-darwin, home-manager, nix-homebrew, homebrew-core, homebrew-cask, homebrew-replicate }:
   let
+    system = "aarch64-darwin";
+    misePkgs = import nixpkgs-mise { inherit system; };
+
     # Helper function to create a Darwin configuration for a specific user
     mkDarwinConfig = username: nix-darwin.lib.darwinSystem {
       modules = [
@@ -55,6 +59,9 @@
           home-manager.useGlobalPkgs = true;
           home-manager.useUserPackages = true;
           home-manager.backupFileExtension = "backup";
+          home-manager.extraSpecialArgs = {
+            misePackage = misePkgs.mise;
+          };
           home-manager.users.${username} = { ... }: {
             imports = [ ../home-manager/home.nix ];
             home.username = username;

--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -54,6 +54,7 @@
         {
           home-manager.useGlobalPkgs = true;
           home-manager.useUserPackages = true;
+          home-manager.backupFileExtension = "backup";
           home-manager.users.${username} = { ... }: {
             imports = [ ../home-manager/home.nix ];
             home.username = username;

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -13,12 +13,12 @@ git pull
 # Check if on macOS
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Updating nix-darwin..."
-    nix flake update "$HOME/dotfiles/nix-darwin"
-    darwin-rebuild switch --flake "$HOME/dotfiles/nix-darwin"
+    nix flake update --flake "$HOME/dotfiles/nix-darwin"
+    sudo darwin-rebuild switch --flake "$HOME/dotfiles/nix-darwin#$USER"
 else
     echo "Updating Home-Manager..."
-    nix flake update "$HOME/dotfiles/home-manager"
-    home-manager switch --flake "$HOME/dotfiles/home-manager"
+    nix flake update --flake "$HOME/dotfiles/home-manager"
+    home-manager switch --flake "$HOME/dotfiles/home-manager#$USER"
 fi
 
 # Update Chezmoi from explicit source dir


### PR DESCRIPTION
## Summary
- Fix `scripts/update.sh` to update subflakes with `--flake`.
- Rebuild the current user nix-darwin/Home Manager target explicitly.
- Preserve OrbStack shell init while allowing Home Manager to back up file collisions.
- Temporarily pin only `mise` to nixpkgs `3e41b24` (`mise 2026.6.5`) while newer nixpkgs builds fail on Darwin.

## Validation
- `bash -n scripts/update.sh`
- `zsh -n chezmoi/dot_config/zsh/custom.zsh`
- `nix flake check ./nix-darwin --no-build`
- `nix flake check ./home-manager --no-build`
- `nix build --no-link --print-out-paths` for pinned `mise` -> `mise-2026.6.5`