### PR TITLE
feat(opencode): add TokenScope plugin

### DIFF
--- a/chezmoi/dot_config/opencode/README.md
+++ b/chezmoi/dot_config/opencode/README.md
@@ -8,6 +8,7 @@ Configuration for [OpenCode][opencode], an AI-powered coding assistant.
 | ----------------------------- | -------------------------------------------------------- |
 | `opencode.json`               | Main config: MCP, plugins, providers, model definitions  |
 | `create_package.json`         | Source manifest for bun-managed plugin dependencies      |
+| `command/tokenscope.md`       | `/tokenscope` command prompt for TokenScope reports       |
 
 ## Providers
 
@@ -42,6 +43,7 @@ rendered from `op://Software/Executor Cloud API Key/password` and
 | Plugin                                        | Purpose                     |
 | --------------------------------------------- | --------------------------- |
 | [opencode-openai-codex-auth][codex-auth]      | OpenAI OAuth authentication |
+| [@ramtinj95/opencode-tokenscope][tokenscope]  | Token usage and cost reports |
 
 ## Runtime Files (Not Managed)
 
@@ -62,6 +64,9 @@ opencode /models
 
 # Connect to a provider
 opencode /connect openai
+
+# Analyze token usage for the current session
+opencode /tokenscope
 ```
 
 ## References
@@ -71,4 +76,5 @@ opencode /connect openai
 [opencode-providers]: https://opencode.ai/docs/providers/
 [openrouter]: https://openrouter.ai/
 [codex-auth]: https://github.com/code-yeongyu/opencode-openai-codex-auth
+[tokenscope]: https://github.com/ramtinJ95/opencode-tokenscope
 [openai]: https://platform.openai.com/

--- a/chezmoi/dot_config/opencode/command/tokenscope.md
+++ b/chezmoi/dot_config/opencode/command/tokenscope.md
@@ -1,0 +1,7 @@
+---
+description: Analyze token usage across the current session with detailed breakdowns by category
+---
+
+Call the tokenscope tool directly without delegating to other agents.
+Leave sessionID unset unless the user explicitly asked to analyze a different session.
+Then cat the token-usage-output.txt. DONT DO ANYTHING ELSE WITH THE OUTPUT.

--- a/chezmoi/dot_config/opencode/create_package.json
+++ b/chezmoi/dot_config/opencode/create_package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "@opencode-ai/plugin": "1.1.11",
+    "@opencode-ai/plugin": "1.17.14",
+    "@ramtinj95/opencode-tokenscope": "^1.7.2",
     "opencode-openai-codex-auth": "^4.4.0"
   }
 }

--- a/chezmoi/dot_config/opencode/private_opencode.json.tmpl
+++ b/chezmoi/dot_config/opencode/private_opencode.json.tmpl
@@ -3,7 +3,8 @@
   "model": "fireworks-ai/accounts/fireworks/models/kimi-k2p6",
   "small_model": "opencode/mimo-v2-omni-free",
   "plugin": [
-    "opencode-openai-codex-auth"
+    "opencode-openai-codex-auth",
+    "@ramtinj95/opencode-tokenscope"
   ],
   "mcp": {
     "executor": {


### PR DESCRIPTION
## Summary

Add TokenScope to the Chezmoi-managed OpenCode configuration so OpenCode can report token usage from the `/tokenscope` command.

Changes include:
- registering [`@ramtinj95/opencode-tokenscope`](https://github.com/ramtinJ95/opencode-tokenscope) in `opencode.json.tmpl`
- adding the npm dependency and compatible `@opencode-ai/plugin` version
- managing `command/tokenscope.md` through Chezmoi
- documenting the plugin and quick command usage

## Validation

- `jq empty chezmoi/dot_config/opencode/create_package.json`
- Stubbed existing 1Password template values in `private_opencode.json.tmpl` and parsed the result with `jq empty`

Direct `chezmoi execute-template` is currently blocked locally by 1Password desktop integration failing to sign in, before this config change is evaluated.
