### PR TITLE
build(mise): bump nixpkgs pin

### DIFF
--- a/home-manager/flake.lock
+++ b/home-manager/flake.lock
@@ -38,17 +38,17 @@
     },
     "nixpkgs-mise": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       }
     },

--- a/home-manager/flake.nix
+++ b/home-manager/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     # Specify the source of Home Manager and Nixpkgs.
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-mise.url = "github:NixOS/nixpkgs/3e41b24abd260e8f71dbe2f5737d24122f972158";
+    nixpkgs-mise.url = "github:NixOS/nixpkgs/f205b5574fd0cb7da5b702a2da51507b7f4fdd1b";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -141,17 +141,17 @@
     },
     "nixpkgs-mise": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       }
     },

--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs-mise.url = "github:NixOS/nixpkgs/3e41b24abd260e8f71dbe2f5737d24122f972158";
+    nixpkgs-mise.url = "github:NixOS/nixpkgs/f205b5574fd0cb7da5b702a2da51507b7f4fdd1b";
     
     nix-darwin = {
       url = "github:LnL7/nix-darwin";


### PR DESCRIPTION
## Summary

- Bump the dedicated `nixpkgs-mise` input in both flakes.
- Update `nix-darwin/flake.lock` and `home-manager/flake.lock` to the same new revision.
- Move Mise from `2026.6.5` to the latest version currently available from Nixpkgs, `2026.7.0`.

Upstream Mise `2026.7.1` exists, but current Nixpkgs `nixpkgs-unstable` and `master` both still package `2026.7.0`.

## Validation run here

- `nix eval --raw github:NixOS/nixpkgs/f205b5574fd0cb7da5b702a2da51507b7f4fdd1b#mise.version` -> `2026.7.0`
- `nix flake metadata /Users/kevinchen/dotfiles/nix-darwin`
- `nix flake metadata /Users/kevinchen/dotfiles/home-manager`

## Commands for local validation

```sh
# confirm the pinned nixpkgs-mise input provides the expected Mise version
nix eval --raw --impure --expr 'let flake = builtins.getFlake "git+file:///Users/kevinchen/dotfiles?dir=nix-darwin"; in flake.inputs.nixpkgs-mise.legacyPackages.aarch64-darwin.mise.version'

# optional non-switching build check
nix build ~/dotfiles/nix-darwin#darwinConfigurations.default.system

# preferred system apply path on macOS
darwin-rebuild switch --flake ~/dotfiles/nix-darwin#default

# after switching, verify the active binary and locked install behavior
mise --version
mise install --dry-run
```

## Follow-up

- Bump `nixpkgs-mise` again when Nixpkgs packages Mise `2026.7.1`.