### PR TITLE
feat(secrets): bootstrap chezmoi age identities

### DIFF
--- a/.agents/skills/chezmoi-secret-template/SKILL.md
+++ b/.agents/skills/chezmoi-secret-template/SKILL.md
@@ -1,34 +1,36 @@
 ---
 name: chezmoi-secret-template
-description: Create and maintain secret-backed Chezmoi shell templates in `chezmoi/dot_config/shell/*.sh.tmpl` using 1Password references. Use when adding API tokens or credentials, migrating plaintext shell env vars to templates, validating template rendering, or wiring new secret modules into shell startup.
+description: Create and maintain age-encrypted Chezmoi secret files and shell configuration. Use when adding API tokens or credentials, migrating 1Password templates or plaintext values, validating decryption, or wiring secret modules into shell startup.
 ---
 
 # Chezmoi Secret Template
 
 ## Overview
-Handle secret-bearing shell configuration using Chezmoi templates and 1Password lookups, without exposing raw secret values in repo files or logs.
+Handle secret-bearing configuration using Chezmoi's age encryption with rage,
+without exposing plaintext values or the private identity in the repository or
+command output.
 
 ## Workflow
 1. Identify secret variables and target shell module file.
-2. Create or update `chezmoi/dot_config/shell/<name>.sh.tmpl`.
-3. Use `onepasswordRead` references instead of literal secret values.
+2. Confirm `~/.config/chezmoi/key.txt` exists and is mode `0600`.
+3. Add the target with `chezmoi add --encrypt`; never hand-write ciphertext.
 4. Ensure shell module loading is wired in `chezmoi/dot_config/zsh/custom.zsh` when adding a new module.
 5. Validate template rendering and provide safe apply commands.
 
 ## Template Rules
-- Use `.sh.tmpl` for any secret-backed exports.
+- Use Chezmoi's encrypted source form for secret-backed exports.
 - Keep non-secret aliases/functions in plain `.sh` files.
-- Reference 1Password items using `{{ onepasswordRead "op://..." }}`.
+- Do not add new `onepasswordRead` references; migrate existing ones to age.
 - Avoid printing rendered secrets in command output or summaries.
 
 ## Validation Steps
-1. Render-check template syntax:
-   - `chezmoi execute-template < chezmoi/dot_config/shell/<name>.sh.tmpl`
+1. Confirm Chezmoi can decrypt and verify targets without printing secrets:
+   - `chezmoi verify`
 2. Apply from repo source:
    - `chezmoi apply --source=$HOME/dotfiles/chezmoi`
 3. Reload shell session or source the generated file as needed.
 
 ## Guardrails
-- Never commit plaintext secrets.
+- Never commit plaintext secrets or `~/.config/chezmoi/key.txt`.
 - Never move secret-backed exports into `home-manager/home.nix`.
 - Keep variable names stable to avoid breaking downstream tooling.

--- a/.agents/skills/dotfiles-change-router/SKILL.md
+++ b/.agents/skills/dotfiles-change-router/SKILL.md
@@ -25,7 +25,7 @@ Route each requested change to the smallest correct file set before editing anyt
 | global agent skills for `~/.agents/skills` | `chezmoi/dot_agents/skills/` | Use for skills that should be available across repos/tools on this machine |
 | repo-local dotfiles skills | top-level `.agents/skills/` | Use only for skills specific to maintaining this dotfiles repo |
 | personal shell behavior and fast iteration aliases | `chezmoi/dot_config/shell/*.sh` | Use plain `.sh` for non-secret config |
-| secret-backed env vars | `chezmoi/dot_config/shell/*.sh.tmpl` | Use `onepasswordRead` templates, never hardcode secrets |
+| secret-backed env vars | age-encrypted files under `chezmoi/dot_config/shell/` | Add with `chezmoi add --encrypt`; never hardcode secrets or commit the identity |
 | zsh load order/path wiring | `chezmoi/dot_config/zsh/custom.zsh` | Update when adding a new shell module file |
 | automation workflow scripts | `scripts/*.sh` | Keep idempotent and non-destructive defaults |
 | operator guidance for scripts | `scripts/AGENTS.md` | Update when behavior/contracts change |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The active configuration has two owners:
 - **mise** manages machine-global packages, macOS defaults, language runtimes,
   and development CLI versions.
 - **Chezmoi** manages dotfiles, shell behavior, application configuration,
-  machine-specific templates, and 1Password-backed secrets.
+  machine-specific templates, and age-encrypted secrets.
 
 The previous `nix-darwin/` and `home-manager/` configurations remain in the
 repository temporarily as a rollback reference. They are not called by the
@@ -47,6 +47,7 @@ After reviewing the dry run, apply the configuration:
 
 ```bash
 export MISE_GLOBAL_CONFIG_FILE="$HOME/dotfiles/chezmoi/dot_config/mise/config.toml"
+export CHEZMOI_AGE_IDENTITY_FILE=/path/to/key.txt
 ~/.local/bin/mise bootstrap --yes --update
 ~/.local/bin/mise bootstrap status --missing
 ```
@@ -57,11 +58,41 @@ shell startup files, including mise activation and login-shell shims. The
 declarative phases are idempotent and skip state that already matches the
 configuration.
 
-### 1Password
+### Age identity
 
-Install and open the 1Password desktop app, then enable **Settings > Developer
-> Integrate with 1Password CLI**. The bootstrap package phase installs the CLI;
-the desktop integration authorizes Chezmoi's secret templates.
+The age private identity is the one irreducible bootstrap secret. Copy it from
+removable media or another trusted path; never commit it. Mise installs `rage`
+before its Chezmoi task runs. The task copies the supplied identity to
+`~/.config/chezmoi/key.txt` with mode `0600`, initializes Chezmoi's age
+configuration, and applies the source state.
+
+Only the machine establishing the repository's first encrypted file should
+generate an identity. While no `.age` source files exist, run:
+
+```bash
+CHEZMOI_AGE_GENERATE=1 mise bootstrap --yes
+```
+
+Back up `~/.config/chezmoi/key.txt` outside this repository before encrypting
+secrets. Once encrypted source files exist, the provisioning script refuses to
+generate a replacement key because it could not decrypt them.
+
+Age protects ciphertext committed to Git; it does not hide secrets from a
+process that can read the private identity on the machine. Agents with access
+to `~/.config/chezmoi/key.txt` can decrypt every file addressed to that key.
+Use separate identities and OS-level access boundaries if secrets need distinct
+agent access policies.
+
+Migrate each existing 1Password-backed target only when its rendered value is
+available locally:
+
+```bash
+chezmoi add --encrypt ~/.config/shell/private_example.sh
+```
+
+Verify the encrypted source file, remove its old `onepasswordRead` template,
+and apply again. Do not remove the 1Password package until all references found
+by `grep -R onepasswordRead chezmoi` have been migrated.
 
 ## Daily Usage
 
@@ -110,8 +141,9 @@ Add macOS preferences to the friendly `[bootstrap.macos.*]` sections or to
 `[bootstrap.macos.defaults]` for raw scalar defaults.
 
 Keep personal files and shell behavior under `chezmoi/`. Secret environment
-variables belong in `.tmpl` files using 1Password references; never commit
-plaintext credentials.
+variables belong in age-encrypted Chezmoi source files; never commit plaintext
+credentials or the age identity. Existing 1Password templates are transitional
+until their values have been migrated into encrypted source files.
 
 ## Chezmoi Commands
 

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -1,0 +1,7 @@
+encryption = "age"
+sourceDir = "{{ .chezmoi.homeDir }}/dotfiles/chezmoi"
+
+[age]
+    command = "rage"
+    identity = "{{ .chezmoi.homeDir }}/.config/chezmoi/key.txt"
+    recipient = "{{ output "rage-keygen" "-y" (joinPath .chezmoi.homeDir ".config/chezmoi/key.txt") | trim }}"

--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -33,6 +33,7 @@ minimum_release_age = "7d"
 "brew:podman" = "latest"
 "brew:podman-compose" = "latest"
 "brew:ripgrep" = "latest"
+"brew:rage" = "latest"
 "brew:sesh" = "latest"
 "brew:tmux" = "latest"
 "brew:webp" = "latest"
@@ -66,7 +67,10 @@ AppleKeyboardUIMode = 3
 
 [tasks.bootstrap]
 description = "Apply Chezmoi-managed workstation configuration"
-run = "MISE_BOOTSTRAP_ACTIVE=1 chezmoi apply --source=\"$HOME/dotfiles/chezmoi\""
+run = '''
+"$HOME/dotfiles/scripts/provision-age-identity.sh"
+MISE_BOOTSTRAP_ACTIVE=1 chezmoi init --apply --source="$HOME/dotfiles/chezmoi"
+'''
 
 [tools]
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -22,5 +22,6 @@ echo "Previewing workstation changes..."
 
 echo
 echo "Bootstrap preparation complete. Review the preview, then run:"
-echo "  MISE_GLOBAL_CONFIG_FILE=$MISE_GLOBAL_CONFIG_FILE $MISE_BIN bootstrap --yes --update"
+echo "  Supply the repository age identity from removable media or another trusted path:"
+echo "  CHEZMOI_AGE_IDENTITY_FILE=/path/to/key.txt MISE_GLOBAL_CONFIG_FILE=$MISE_GLOBAL_CONFIG_FILE $MISE_BIN bootstrap --yes --update"
 echo "  MISE_GLOBAL_CONFIG_FILE=$MISE_GLOBAL_CONFIG_FILE $MISE_BIN bootstrap status --missing"

--- a/scripts/provision-age-identity.sh
+++ b/scripts/provision-age-identity.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Provision the private age identity that unlocks Chezmoi's encrypted source files.
+
+set -euo pipefail
+
+identity="${CHEZMOI_AGE_IDENTITY:-$HOME/.config/chezmoi/key.txt}"
+identity_source="${CHEZMOI_AGE_IDENTITY_FILE:-}"
+dotfiles_dir="${DOTFILES_DIR:-$HOME/dotfiles}"
+
+usage() {
+  cat <<'EOF'
+Usage: provision-age-identity.sh [--generate]
+
+Provision ~/.config/chezmoi/key.txt from CHEZMOI_AGE_IDENTITY_FILE. The source
+must be an existing age identity file supplied out-of-band. Use --generate only
+when creating the repository's first identity, not when joining another machine.
+EOF
+}
+
+generate="${CHEZMOI_AGE_GENERATE:-0}"
+case "${1:-}" in
+  "") ;;
+  --generate) generate=1 ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v rage-keygen >/dev/null 2>&1; then
+  echo "rage-keygen is required; run the mise package bootstrap first" >&2
+  exit 1
+fi
+
+if [[ -e "$identity" ]]; then
+  chmod 600 "$identity"
+  rage-keygen -y "$identity" >/dev/null
+  echo "Using existing age identity at $identity"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$identity")"
+
+if [[ -n "$identity_source" ]]; then
+  if [[ ! -f "$identity_source" ]]; then
+    echo "CHEZMOI_AGE_IDENTITY_FILE does not exist: $identity_source" >&2
+    exit 1
+  fi
+  install -m 600 "$identity_source" "$identity"
+elif [[ "$generate" == "1" ]]; then
+  if find "$dotfiles_dir/chezmoi" -type f -name '*.age' -print -quit | grep -q .; then
+    echo "Refusing to generate a new identity: encrypted source files already exist" >&2
+    echo "Provision the repository's existing identity with CHEZMOI_AGE_IDENTITY_FILE" >&2
+    exit 1
+  fi
+  umask 077
+  rage-keygen -o "$identity"
+else
+  cat >&2 <<EOF
+Missing age identity: $identity
+
+Copy the repository identity to this machine, then rerun with:
+  CHEZMOI_AGE_IDENTITY_FILE=/path/to/key.txt mise bootstrap --yes
+
+Use CHEZMOI_AGE_GENERATE=1 only once, when establishing the first identity. A
+newly generated key cannot decrypt existing secrets.
+EOF
+  exit 1
+fi
+
+chmod 600 "$identity"
+rage-keygen -y "$identity" >/dev/null
+echo "Provisioned age identity at $identity"


### PR DESCRIPTION
AI-assisted.

## What this does

- installs `rage` in Mise's package phase before the Chezmoi task runs
- provisions `~/.config/chezmoi/key.txt` from an out-of-band identity with mode `0600`
- supports one-time identity generation only while the repo has no encrypted `.age` source files
- initializes Chezmoi with `rage` plus the derived recipient before applying managed files
- updates repo guidance so new secrets use `chezmoi add --encrypt` instead of new `onepasswordRead` references

## Migration boundary

This intentionally leaves the existing 1Password templates and package in place. Their rendered values are not available in the current environment, so removing them would break `chezmoi apply`. Once those values are locally available, each target can be added with `chezmoi add --encrypt`, its old template removed, and the 1Password package dropped after the final reference is gone.

> [!IMPORTANT]
> The age private identity is the irreducible bootstrap secret and must be transferred to new machines out-of-band. Any agent that can read that identity can decrypt every file addressed to it; age protects repository ciphertext, not secrets from local processes.

## Validation

- `shellcheck` passed for both bootstrap scripts
- `bash -n` and `zsh -n` passed for both bootstrap scripts
- `mise fmt --check` passed for the global config
- `mise bootstrap --dry-run` resolved `rage 0.12.1` and ordered the Chezmoi task after package installation
- isolated `chezmoi init` generated an age configuration with the expected identity and derived recipient
- `git diff --check` passed
