### PR TITLE
chore(mcp): standardize Executor server configs

### DIFF
--- a/chezmoi/dot_codex/modify_private_config.toml.tmpl
+++ b/chezmoi/dot_codex/modify_private_config.toml.tmpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Manage only the Executor MCP stanzas in ~/.codex/config.toml.
+# Keep only the Executor MCP stanzas in ~/.codex/config.toml.
 
 set -euo pipefail
 
@@ -25,7 +25,7 @@ args = ["mcp"]
 '''
 
 pattern = re.compile(
-    r'(?ms)^\[mcp_servers\.(?:executor|executor-desktop|executor-cloud)(?:\.[^\]]+)?\]\n.*?(?=^\[|\Z)'
+    r'(?ms)^\[mcp_servers\.[^\]]+\]\n.*?(?=^\[|\Z)'
 )
 text = pattern.sub("", text).rstrip()
 text = text + "\n\n" + block if text else block

--- a/chezmoi/dot_config/crush/modify_private_crush.json.tmpl
+++ b/chezmoi/dot_config/crush/modify_private_crush.json.tmpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Manage only the Executor MCP entries in ~/.config/crush/crush.json.
+# Keep only the Executor MCP entries in ~/.config/crush/crush.json.
 
 set -euo pipefail
 
@@ -16,26 +16,24 @@ path = Path(sys.argv[1])
 raw = path.read_text().strip()
 data = json.loads(raw) if raw else {"$schema": "https://charm.land/crush.json"}
 
-servers = data.setdefault("mcp", {})
-for name in ("executor", "executor-desktop", "executor-cloud"):
-    servers.pop(name, None)
-
-servers["executor"] = {
-    "type": "stdio",
-    "command": "mise",
-    "args": [
-        "exec", "--", "sfw", "npx", "-y", "mcp-remote@0.1.38",
-        "https://executor.sh/kevin-chen-s-organization/mcp",
-        "--transport", "http-only",
-    ],
-    "env": {"SFW_SKIP_UPDATE_CHECK": "1"},
-    "timeout": 120,
-}
-servers["executor-desktop"] = {
-    "type": "stdio",
-    "command": "executor",
-    "args": ["mcp"],
-    "timeout": 120,
+data["mcp"] = {
+    "executor": {
+        "type": "stdio",
+        "command": "mise",
+        "args": [
+            "exec", "--", "sfw", "npx", "-y", "mcp-remote@0.1.38",
+            "https://executor.sh/kevin-chen-s-organization/mcp",
+            "--transport", "http-only",
+        ],
+        "env": {"SFW_SKIP_UPDATE_CHECK": "1"},
+        "timeout": 120,
+    },
+    "executor-desktop": {
+        "type": "stdio",
+        "command": "executor",
+        "args": ["mcp"],
+        "timeout": 120,
+    },
 }
 
 print(json.dumps(data, indent=2))

--- a/chezmoi/dot_config/opencode/modify_private_opencode.json.tmpl
+++ b/chezmoi/dot_config/opencode/modify_private_opencode.json.tmpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Manage only the Executor MCP entries in ~/.config/opencode/opencode.json.
+# Keep only the Executor MCP entries in ~/.config/opencode/opencode.json.
 
 set -euo pipefail
 
@@ -16,19 +16,17 @@ path = Path(sys.argv[1])
 raw = path.read_text().strip()
 data = json.loads(raw) if raw else {"$schema": "https://opencode.ai/config.json"}
 
-servers = data.setdefault("mcp", {})
-for name in ("executor", "executor-desktop", "executor-cloud"):
-    servers.pop(name, None)
-
-servers["executor"] = {
-    "type": "remote",
-    "url": "https://executor.sh/kevin-chen-s-organization/mcp",
-    "enabled": True,
-}
-servers["executor-desktop"] = {
-    "type": "local",
-    "command": ["executor", "mcp"],
-    "enabled": True,
+data["mcp"] = {
+    "executor": {
+        "type": "remote",
+        "url": "https://executor.sh/kevin-chen-s-organization/mcp",
+        "enabled": True,
+    },
+    "executor-desktop": {
+        "type": "local",
+        "command": ["executor", "mcp"],
+        "enabled": True,
+    },
 }
 
 print(json.dumps(data, indent=2))

--- a/chezmoi/modify_private_dot_claude.json.tmpl
+++ b/chezmoi/modify_private_dot_claude.json.tmpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Manage only the Executor MCP entries in ~/.claude.json.
+# Keep only the Executor MCP entries in ~/.claude.json.
 
 set -euo pipefail
 
@@ -16,18 +16,16 @@ path = Path(sys.argv[1])
 raw = path.read_text().strip()
 data = json.loads(raw) if raw else {}
 
-servers = data.setdefault("mcpServers", {})
-for name in ("executor", "executor-desktop", "executor-cloud"):
-    servers.pop(name, None)
-
-servers["executor"] = {
-    "type": "http",
-    "url": "https://executor.sh/kevin-chen-s-organization/mcp",
-}
-servers["executor-desktop"] = {
-    "type": "stdio",
-    "command": "executor",
-    "args": ["mcp"],
+data["mcpServers"] = {
+    "executor": {
+        "type": "http",
+        "url": "https://executor.sh/kevin-chen-s-organization/mcp",
+    },
+    "executor-desktop": {
+        "type": "stdio",
+        "command": "executor",
+        "args": ["mcp"],
+    },
 }
 
 print(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary
- configure Claude, Codex, OpenCode, and Crush with only Executor cloud and desktop MCPs
- remove existing non-Executor MCP entries on every Chezmoi apply
- retain the existing client-specific transport settings

## Validation
- rendered each Chezmoi transform and verified only `executor` and `executor-desktop` remain
- applied the four managed targets and confirmed their configs are idempotent
- verified `opencode mcp list` reports two connected servers