### PR TITLE
chore(mise): add rage 0.12.0 via aqua

### DIFF
--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -139,6 +139,7 @@ bun = "1.3.14"
 "aqua:terrastruct/d2" = "0.7.1"          # Diagram language
 "aqua:typst/typst" = "0.15.0"
 "aqua:starship/starship" = "1.26.0"
+"aqua:str4d/rage" = "0.12.0"             # age encryption in Rust
 "aqua:golangci/golangci-lint" = "2.12.2" # Go linter aggregator
 "github:astral-sh/uv" = "0.11.29"
 "aqua:aws/aws-cli" = "2.35.24"

--- a/chezmoi/dot_config/mise/mise.lock
+++ b/chezmoi/dot_config/mise/mise.lock
@@ -157,6 +157,15 @@ checksum = "sha256:c40b27b11f580411e068f2fa6c1be7830a387c0bc47a94d1d37f32b054c53
 url = "https://github.com/starship/starship/releases/download/v1.26.0/starship-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/starship/starship/releases/assets/460374577"
 
+[[tools."aqua:str4d/rage"]]
+version = "0.12.0"
+backend = "aqua:str4d/rage"
+
+[tools."aqua:str4d/rage"."platforms.macos-arm64"]
+checksum = "sha256:12475322e7c03ff5514cde5ce78e11a23ccd0beaef905d17401b643af29e3dd4"
+url = "https://github.com/str4d/rage/releases/download/v0.12.0/rage-v0.12.0-arm64-darwin.tar.gz"
+url_api = "https://api.github.com/repos/str4d/rage/releases/assets/474939476"
+
 [[tools."aqua:terrastruct/d2"]]
 version = "0.7.1"
 backend = "aqua:terrastruct/d2"


### PR DESCRIPTION
AI-assisted.

- Adds `aqua:str4d/rage` = `0.12.0` (latest release) to `[tools]` in the mise config — [rage](https://github.com/str4d/rage) is a Rust implementation of age file encryption.
- Adds the matching `mise.lock` entry (macos-arm64 tarball URL + sha256) because mise runs in locked mode here and refuses to install tools without a lockfile entry.
- Verified locally: `chezmoi apply` + `mise install aqua:str4d/rage` succeed in locked mode, and `rage --version` reports `0.12.0`.

## After merge (other machines)

- `dot-update` (or `chezmoi apply --source="$HOME/dotfiles/chezmoi"` followed by `mise install`) picks up the tool; no manual lockfile step needed since the entry ships in this PR.

> [!NOTE]
> While generating the lock entry, `mise lock --global` also tried to rewrite the existing yq macos-arm64 entry to point at the **amd64** binary (`yq_darwin_amd64`) — likely a mise/aqua registry bug. That churn was reverted so this diff is rage-only, but expect it to resurface next time `./scripts/update-tools.sh` runs `mise lock`; double-check the yq entry in that diff.
