### PR TITLE
chore(mise): add rtk and Hugging Face CLI tools

### DIFF
--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -95,6 +95,7 @@ bun = "1.3.14"
 # Python CLI Tools from PyPI
 # ============================================================================
 "pipx:parallel-web-tools" = { version = "0.7.1", extras = "cli" }
+"pipx:huggingface_hub" = "1.23.0" # hf CLI
 
 # ============================================================================
 # Development Tools from Cargo (Rust tools)
@@ -113,6 +114,7 @@ bun = "1.3.14"
 # Tools from GitHub Releases (Go & other binaries)
 # ============================================================================
 # Chezmoi is installed during the package phase before the bootstrap task.
+"github:rtk-ai/rtk" = "0.28.2"                 # Token-efficient CLI for coding agents
 "github:x-motemen/ghq" = "1.10.1"
 "github:cli/cli" = "2.96.0"
 "github:abhinav/git-spice" = "0.31.0"

--- a/chezmoi/dot_config/mise/mise.lock
+++ b/chezmoi/dot_config/mise/mise.lock
@@ -286,6 +286,15 @@ checksum = "sha256:de9ab62dd90461cd1df1e37b78e780690d75490f4bab1674cbb4a1f75b90c
 url = "https://github.com/libkrun/krunkit/releases/download/v1.3.2/krunkit-podman-unsigned-1.3.2.tgz"
 url_api = "https://api.github.com/repos/libkrun/krunkit/releases/assets/465341860"
 
+[[tools."github:rtk-ai/rtk"]]
+version = "0.28.2"
+backend = "github:rtk-ai/rtk"
+
+[tools."github:rtk-ai/rtk"."platforms.macos-arm64"]
+checksum = "sha256:5dede8ac36648960a3ad52611856b9047a7817b755750d2bdbda8d4e9931db4d"
+url = "https://github.com/rtk-ai/rtk/releases/download/v0.28.2/rtk-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/371020972"
+
 [[tools."github:sigoden/projclean"]]
 version = "0.9.0"
 backend = "github:sigoden/projclean"
@@ -352,6 +361,10 @@ backend = "npm:sfw"
 [[tools."npm:wrangler"]]
 version = "4.111.0"
 backend = "npm:wrangler"
+
+[[tools."pipx:huggingface_hub"]]
+version = "1.23.0"
+backend = "pipx:huggingface_hub"
 
 [[tools."pipx:parallel-web-tools"]]
 version = "0.7.1"


### PR DESCRIPTION
Adds two pinned Mise-managed CLI tools:

- [`rtk`](https://github.com/rtk-ai/rtk) 0.28.2 from the GitHub release
- [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) 1.23.0 through pipx

Validation: `rtk --version` reports `rtk 0.28.2`; Mise reports both tools installed.

AI-assisted.