### PR TITLE
feat: configure Maki tools and MCP connections

### DIFF
--- a/chezmoi/dot_config/maki/executable_ast-grep-mcp.sh
+++ b/chezmoi/dot_config/maki/executable_ast-grep-mcp.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Adapted from https://github.com/tontinton/makiconf/blob/main/ast-grep-mcp.sh
+set -euo pipefail
+
+AST_GREP="${ASTGREP_BIN:-ast-grep}"
+
+respond() {
+  jq -cn --argjson id "$1" --argjson result "$2" \
+    '{jsonrpc:"2.0", id:$id, result:$result}'
+}
+
+respond_error() {
+  jq -cn --argjson id "$1" --arg message "$2" \
+    '{jsonrpc:"2.0", id:$id, error:{code:-32602, message:$message}}'
+}
+
+tool_result() {
+  jq -cn --argjson id "$1" --arg text "$2" --argjson is_error "$3" \
+    '{jsonrpc:"2.0", id:$id, result:{content:[{type:"text", text:$text}], isError:$is_error}}'
+}
+
+tools_list() {
+  jq -cn '{
+    tools: [
+      {
+        name: "search",
+        description: "Find code by AST pattern. $NAME matches one node; $$$NAME matches multiple nodes.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            pattern: {type:"string", description:"AST pattern with $NAME or $$$NAME metavariables."},
+            language: {type:"string", description:"Source language, such as javascript, typescript, python, rust, go, java, c, or cpp."},
+            paths: {type:"array", items:{type:"string"}, description:"Directories or files to search; defaults to the current directory."},
+            globs: {type:"array", items:{type:"string"}, description:"Optional glob filters, such as *.ts or !test/**."}
+          },
+          required: ["pattern", "language"]
+        }
+      },
+      {
+        name: "search_and_replace",
+        description: "Mutating AST search-and-replace. Preview matches, then update every match using captured metavariables.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            pattern: {type:"string", description:"AST pattern to match."},
+            rewrite: {type:"string", description:"Replacement using metavariables captured by the pattern."},
+            language: {type:"string", description:"Source language."},
+            paths: {type:"array", items:{type:"string"}, description:"Directories or files to update; defaults to the current directory."},
+            globs: {type:"array", items:{type:"string"}, description:"Optional glob filters."}
+          },
+          required: ["pattern", "rewrite", "language"]
+        }
+      }
+    ]
+  }'
+}
+
+handle_tool_call() {
+  local id="$1"
+  local body="$2"
+  local tool_name pattern language rewrite
+  tool_name="$(jq -r '.params.name // empty' <<<"$body")"
+  pattern="$(jq -r '.params.arguments.pattern // empty' <<<"$body")"
+  language="$(jq -r '.params.arguments.language // empty' <<<"$body")"
+  rewrite="$(jq -r '.params.arguments.rewrite // empty' <<<"$body")"
+
+  if [[ -z "$pattern" || -z "$language" ]]; then
+    tool_result "$id" "Error: pattern and language are required." true
+    return
+  fi
+
+  local -a common_args preview_args apply_args
+  common_args=(run --pattern "$pattern" --lang "$language")
+
+  while IFS= read -r glob; do
+    [[ -n "$glob" ]] && common_args+=(--globs "$glob")
+  done < <(jq -r '.params.arguments.globs[]?' <<<"$body")
+
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && common_args+=("$path")
+  done < <(jq -r '.params.arguments.paths[]?' <<<"$body")
+
+  preview_args=("${common_args[@]}" --json=compact)
+  if [[ "$tool_name" == "search_and_replace" ]]; then
+    if [[ -z "$rewrite" ]]; then
+      tool_result "$id" "Error: rewrite is required for search_and_replace." true
+      return
+    fi
+    preview_args+=("--rewrite=$rewrite")
+  elif [[ "$tool_name" != "search" ]]; then
+    tool_result "$id" "Error: unknown tool $tool_name." true
+    return
+  fi
+
+  local output exit_code=0
+  output="$("$AST_GREP" "${preview_args[@]}" 2>&1)" || exit_code=$?
+
+  if [[ $exit_code -eq 1 || -z "$output" || "$output" == "[]" ]]; then
+    tool_result "$id" "No matches found." false
+    return
+  elif [[ $exit_code -ne 0 ]]; then
+    tool_result "$id" "ast-grep error (exit $exit_code): $output" true
+    return
+  fi
+
+  local count details message
+  count="$(jq 'length' <<<"$output")"
+
+  if [[ "$tool_name" == "search_and_replace" ]]; then
+    apply_args=("${common_args[@]}" "--rewrite=$rewrite" --update-all)
+    local apply_output apply_code=0
+    apply_output="$("$AST_GREP" "${apply_args[@]}" 2>&1)" || apply_code=$?
+    if [[ $apply_code -ne 0 ]]; then
+      tool_result "$id" "ast-grep replacement failed (exit $apply_code): $apply_output" true
+      return
+    fi
+    details="$(jq -r '.[] | "\(.file):\(.range.start.line + 1):\(.range.start.column + 1)\n  matched: \(.text)\n  replacement: \(.replacement // "N/A")"' <<<"$output")"
+    printf -v message 'Replaced %s matches.\n\n%s' "$count" "$details"
+    tool_result "$id" "$message" false
+  else
+    details="$(jq -r '.[] | "\(.file):\(.range.start.line + 1):\(.range.start.column + 1)\n  \(.lines | gsub("^\\s+"; "") | gsub("\\n$"; ""))"' <<<"$output")"
+    printf -v message 'Found %s matches:\n\n%s' "$count" "$details"
+    tool_result "$id" "$message" false
+  fi
+}
+
+while IFS= read -r line; do
+  line="${line%%$'\r'}"
+  [[ -z "$line" ]] && continue
+
+  id="$(jq -c '.id // null' <<<"$line")"
+  method="$(jq -r '.method // empty' <<<"$line")"
+
+  case "$method" in
+    initialize)
+      result="$(jq -cn '{
+        protocolVersion:"2024-11-05",
+        capabilities:{tools:{listChanged:false}},
+        serverInfo:{name:"ast-grep", version:"1.0.0"}
+      }')"
+      respond "$id" "$result"
+      ;;
+    notifications/initialized)
+      ;;
+    tools/list)
+      respond "$id" "$(tools_list)"
+      ;;
+    tools/call)
+      handle_tool_call "$id" "$line"
+      ;;
+    ping)
+      respond "$id" '{}'
+      ;;
+    *)
+      [[ "$id" != "null" ]] && respond_error "$id" "Method not found"
+      ;;
+  esac
+done

--- a/chezmoi/dot_config/maki/init.lua
+++ b/chezmoi/dot_config/maki/init.lua
@@ -1,0 +1,3 @@
+maki.setup({})
+
+require("semble")

--- a/chezmoi/dot_config/maki/lua/semble.lua
+++ b/chezmoi/dot_config/maki/lua/semble.lua
@@ -1,0 +1,140 @@
+-- Adapted from https://github.com/tontinton/makiconf/blob/main/lua/semble.lua
+local truncate = require("maki.truncate")
+local ToolView = require("maki.tool_view")
+
+local DEFAULT_TOP_K = 5
+
+if maki.fn.executable("semble") == 0 then
+  return
+end
+
+local function semble_view_opts(ctx)
+  local tol = ctx:tool_output_lines()
+  return { max_lines = (tol and tol.other) or 5, keep = "head" }
+end
+
+local function shell_quote(s)
+  return "'" .. s:gsub("'", "'\\''") .. "'"
+end
+
+local cwd = maki.uv.cwd() or "."
+
+maki.api.register_prompt_hint({
+  slot = "tool_usage",
+  content = '- Use **semble** for "How does X work?" questions or when you don\'t know the right names. Use **grep** for known symbols.',
+})
+
+maki.api.register_prompt_hint({
+  slot = "efficient_tools",
+  content = "semble",
+})
+
+maki.api.register_tool({
+  name = "semble",
+  description = [[Search code semantically using semble.
+
+- Finds code by meaning, not keywords. Best when you don't know the exact names.
+- Returns chunks with file:line and relevance scores.
+- Use for: "How does X work?", "Where is X implemented?", cross-cutting concerns.
+- Use grep instead for known symbols or exhaustive reference searches.]],
+
+  schema = {
+    type = "object",
+    properties = {
+      query = { type = "string", description = "Natural language or symbol query", required = true },
+      path = { type = "string", description = "Directory to search" },
+      top_k = { type = "integer", description = "Number of results (default " .. DEFAULT_TOP_K .. ")" },
+      content = { type = "string", description = "code (default), docs, config, or all" },
+    },
+  },
+  header = function(input)
+    local buf = maki.ui.buf()
+    local spans = { { input.query or "", "tool" } }
+    if input.path then
+      spans[#spans + 1] = { " in ", "dim" }
+      spans[#spans + 1] = { input.path, "path" }
+    end
+    buf:line(spans)
+    return buf
+  end,
+
+  restore = function(_input, output, _is_error, ctx)
+    return ToolView.restore(output, semble_view_opts(ctx))
+  end,
+
+  handler = function(input, ctx)
+    local query = input.query
+    if not query then
+      return "error: query is required"
+    end
+
+    local config = ctx:config()
+    local max_lines = (config and config.max_output_lines) or 2000
+    local max_bytes = (config and config.max_output_bytes) or (50 * 1024)
+
+    local top_k = input.top_k or DEFAULT_TOP_K
+    local path = input.path or cwd
+    local cmd = "semble search " .. shell_quote(query) .. " " .. shell_quote(path)
+      .. " --top-k " .. tostring(top_k)
+
+    if input.content then
+      cmd = cmd .. " --content " .. shell_quote(input.content)
+    end
+
+    local buf, view
+    do
+      local b = maki.ui.buf()
+      local v = ToolView.new(b, semble_view_opts(ctx))
+      v:append({ { "Searching...", "dim" } })
+      buf, view = b, v
+      b:on("click", function()
+        v:toggle()
+      end)
+    end
+
+    local output_parts = {}
+    local has_output = false
+
+    local function append_line(line)
+      if #output_parts > 0 then
+        output_parts[#output_parts + 1] = "\n"
+      end
+      output_parts[#output_parts + 1] = line
+    end
+
+    maki.fn.jobstart(cmd, {
+      on_stdout = function(_, line)
+        if not has_output then
+          has_output = true
+          view:clear()
+        end
+        append_line(line)
+        view:append(line)
+      end,
+      on_stderr = function(_, line)
+        if not has_output then
+          has_output = true
+          view:clear()
+        end
+        append_line(line)
+        view:append(line)
+      end,
+      on_exit = function(_, code)
+        local output = table.concat(output_parts)
+        local is_error = code ~= 0
+
+        if output == "" then
+          output = is_error and ("Exit code: " .. code) or "No results found"
+          view:clear()
+          view:append({ { output, "dim" } })
+        end
+
+        local llm_output = truncate(output, max_lines, max_bytes)
+        view:finish()
+        ctx:finish({ llm_output = llm_output, is_error = is_error, body = buf })
+      end,
+    })
+
+    return nil
+  end,
+})

--- a/chezmoi/dot_config/maki/mcp.toml
+++ b/chezmoi/dot_config/maki/mcp.toml
@@ -1,0 +1,2 @@
+[mcp.ast-grep]
+command = ["bash", "-lc", "exec \"$HOME/.config/maki/ast-grep-mcp.sh\""]

--- a/chezmoi/dot_config/maki/mcp.toml
+++ b/chezmoi/dot_config/maki/mcp.toml
@@ -1,2 +1,8 @@
 [mcp.ast-grep]
 command = ["bash", "-lc", "exec \"$HOME/.config/maki/ast-grep-mcp.sh\""]
+
+[mcp.executor]
+url = "https://executor.sh/kevin-chen-s-organization/mcp"
+
+[mcp.executor-desktop]
+command = ["executor", "mcp"]

--- a/chezmoi/dot_config/maki/plugin.toml
+++ b/chezmoi/dot_config/maki/plugin.toml
@@ -1,0 +1,4 @@
+# The Semble plugin reads process state and launches the local `semble` CLI.
+[permissions]
+env = true
+run = true

--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -96,6 +96,7 @@ bun = "1.3.14"
 # ============================================================================
 "pipx:parallel-web-tools" = { version = "0.7.1", extras = "cli" }
 "pipx:huggingface_hub" = "1.23.0" # hf CLI
+"pipx:semble" = "0.5.2"           # Local semantic code search for agents
 
 # ============================================================================
 # Development Tools from Cargo (Rust tools)
@@ -114,6 +115,7 @@ bun = "1.3.14"
 # Tools from GitHub Releases (Go & other binaries)
 # ============================================================================
 # Chezmoi is installed during the package phase before the bootstrap task.
+"github:tontinton/maki" = "0.4.4"              # Context-efficient terminal coding agent
 "github:rtk-ai/rtk" = "0.28.2"                 # Token-efficient CLI for coding agents
 "github:x-motemen/ghq" = "1.10.1"
 "github:cli/cli" = "2.96.0"
@@ -135,6 +137,7 @@ bun = "1.3.14"
 "aqua:ajeetdsouza/zoxide" = "0.10.0"
 "aqua:dprint/dprint" = "0.55.2"
 "aqua:j178/prek" = "0.4.10"
+"aqua:ast-grep/ast-grep" = "0.44.1" # Structural code search used by Maki MCP
 "aqua:chmln/sd" = "1.1.0"                # sed replacement (simpler syntax)
 "aqua:koalaman/shellcheck" = "0.11.0"    # Shell script static analyzer
 "aqua:mikefarah/yq" = "4.53.3"

--- a/chezmoi/dot_config/mise/mise.lock
+++ b/chezmoi/dot_config/mise/mise.lock
@@ -9,6 +9,15 @@ checksum = "sha256:b55ae6f2f5f23d0a6ccb3bd4eeb2af9c7e0a6556e5255c82100e40305129b
 url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.10.0/zoxide-0.10.0-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/ajeetdsouza/zoxide/releases/assets/466316174"
 
+[[tools."aqua:ast-grep/ast-grep"]]
+version = "0.44.1"
+backend = "aqua:ast-grep/ast-grep"
+
+[tools."aqua:ast-grep/ast-grep"."platforms.macos-arm64"]
+checksum = "sha256:0a2fef273b0ff1238b8307add911714f92021d25b919fa3ec9b6b2e046bb29cf"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.44.1/app-aarch64-apple-darwin.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/466368358"
+
 [[tools."aqua:aws/aws-cli"]]
 version = "2.35.24"
 backend = "aqua:aws/aws-cli"
@@ -304,6 +313,15 @@ checksum = "sha256:d21d939d8a82a0f955fb3502dfd7233c077740b9247eab7b3fb4a21c99946
 url = "https://github.com/sigoden/projclean/releases/download/v0.9.0/projclean-v0.9.0-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/sigoden/projclean/releases/assets/414034562"
 
+[[tools."github:tontinton/maki"]]
+version = "0.4.4"
+backend = "github:tontinton/maki"
+
+[tools."github:tontinton/maki"."platforms.macos-arm64"]
+checksum = "sha256:a4db8c80eea68cc3dad25f45c8d9dfcae67e4547f912771433d3cdb834af1bd1"
+url = "https://github.com/tontinton/maki/releases/download/v0.4.4/maki-v0.4.4-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/tontinton/maki/releases/assets/489766727"
+
 [[tools."github:vercel-labs/agent-browser"]]
 version = "0.32.0"
 backend = "github:vercel-labs/agent-browser"
@@ -372,6 +390,10 @@ backend = "pipx:parallel-web-tools"
 
 [tools."pipx:parallel-web-tools".options]
 extras = "cli"
+
+[[tools."pipx:semble"]]
+version = "0.5.2"
+backend = "pipx:semble"
 
 [[tools.pnpm]]
 version = "11.13.1"


### PR DESCRIPTION
AI-assisted.

- manage Maki 0.4.4, Semble 0.5.2, and ast-grep 0.44.1 through Mise with locked artifact metadata
- enable the Semble Lua search tool and a local ast-grep MCP server for structural search and replacement
- connect Maki to Executor Cloud over its OAuth-protected HTTP endpoint and Executor Desktop over local stdio
- keep Maki permission prompts intact while granting only the Lua capabilities required by Semble; runtime OAuth credentials remain outside Chezmoi
- verify Chezmoi convergence and a locked Mise install; `mise doctor` reports no problems
- verify ShellCheck/Bash syntax, Maki tool loading, a live Semble semantic query, and ast-grep MCP search/replace against a temporary fixture
- verify both Executor paths end to end from a Maki/DeepSeek session: Cloud returned GitHub search results and Desktop returned its credential-provider list
- note: no repository-wide prek/pre-commit configuration exists, so that suite was not available
