### PR TITLE
perf(shell): cache machine labels off the prompt path

### DIFF
--- a/chezmoi/dot_config/starship.toml
+++ b/chezmoi/dot_config/starship.toml
@@ -21,7 +21,7 @@ muted = "#6e6a86"
 base = "#191724"
 
 format = """
-$hostname\
+${env_var.machine_kind}\
 $directory\
 $git_branch\
 $git_status\
@@ -138,12 +138,10 @@ style = "love"
 map_symbol = true
 disabled = false
 
-# Avoid network-aware commands in the prompt's hot path.
-[hostname]
-ssh_only = false
-format = "[$hostname](bold rose):"
-trim_at = "."
-disabled = false
+# Zsh detects the work machine once; prompt rendering only reads the result.
+[env_var.machine_kind]
+variable = "STARSHIP_MACHINE_KIND"
+format = "[$env_value](bold rose):"
 
 [battery]
 disabled = true

--- a/chezmoi/dot_config/starship.toml
+++ b/chezmoi/dot_config/starship.toml
@@ -2,8 +2,8 @@
 # Theme: Rose Pine (matches Ghostty)
 
 add_newline = true
-command_timeout = 1000
-scan_timeout = 200
+command_timeout = 500
+scan_timeout = 30
 
 palette = "rose_pine"
 
@@ -21,7 +21,7 @@ muted = "#6e6a86"
 base = "#191724"
 
 format = """
-${custom.machine}\
+$hostname\
 $directory\
 $git_branch\
 $git_status\
@@ -138,20 +138,12 @@ style = "love"
 map_symbol = true
 disabled = false
 
-# Machine identifier - shows Tailscale hostname or IP
-[custom.machine]
-command = '''
-if command -v tailscale >/dev/null 2>&1; then
-  tailscale status --self --json 2>/dev/null | jq -r '.Self.DNSName | split(".") | .[0]' 2>/dev/null
-elif [[ "$OSTYPE" == darwin* ]]; then
-  ipconfig getifaddr en0 2>/dev/null || hostname -s
-else
-  hostname -I 2>/dev/null | awk '{print $1}' || hostname -s
-fi
-'''
-when = "true"
-format = "[$output](bold rose):"
-shell = ["bash", "--noprofile", "--norc"]
+# Avoid network-aware commands in the prompt's hot path.
+[hostname]
+ssh_only = false
+format = "[$hostname](bold rose):"
+trim_at = "."
+disabled = false
 
 [battery]
 disabled = true

--- a/chezmoi/dot_config/starship.toml
+++ b/chezmoi/dot_config/starship.toml
@@ -21,7 +21,7 @@ muted = "#6e6a86"
 base = "#191724"
 
 format = """
-${env_var.machine_kind}\
+${env_var.machine_label}\
 $directory\
 $git_branch\
 $git_status\
@@ -138,9 +138,9 @@ style = "love"
 map_symbol = true
 disabled = false
 
-# Zsh detects the work machine once; prompt rendering only reads the result.
-[env_var.machine_kind]
-variable = "STARSHIP_MACHINE_KIND"
+# Zsh builds this once; prompt rendering only reads the result.
+[env_var.machine_label]
+variable = "STARSHIP_MACHINE_LABEL"
 format = "[$env_value](bold rose):"
 
 [battery]

--- a/chezmoi/dot_config/zsh/custom.zsh
+++ b/chezmoi/dot_config/zsh/custom.zsh
@@ -74,11 +74,82 @@ export PATH="${(j/:/)path}"
 [[ -f ~/.config/shell/zed.sh ]] && source ~/.config/shell/zed.sh
 [[ -f ~/.config/shell/github.sh ]] && source ~/.config/shell/github.sh
 
-# Detect the work machine once instead of probing from every prompt.
+# Build a stable machine label once, then reuse it across every future shell.
 if [[ -d /Applications/Cisco ]]; then
-  export STARSHIP_MACHINE_KIND="work"
+  export STARSHIP_MACHINE_LABEL="work"
 else
-  unset STARSHIP_MACHINE_KIND
+  _starship_machine_cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/starship"
+  _starship_machine_cache="${_starship_machine_cache_dir}/machine-slug"
+  _starship_machine_slug=""
+
+  if [[ -r "$_starship_machine_cache" ]]; then
+    IFS= read -r _starship_machine_slug < "$_starship_machine_cache"
+  fi
+
+  # Cache miss: derive a readable, collision-resistant slug from macOS hardware.
+  if [[ -z "$_starship_machine_slug" ]]; then
+    mkdir -p "$_starship_machine_cache_dir"
+    if mkdir "${_starship_machine_cache}.lock" 2>/dev/null; then
+      () {
+        setopt LOCAL_OPTIONS
+        unsetopt BG_NICE
+        (
+          _starship_hardware_json="$(/usr/sbin/system_profiler SPHardwareDataType -json 2>/dev/null)"
+          _starship_machine_name="$(
+            print -rn -- "$_starship_hardware_json" |
+              /usr/bin/plutil -extract SPHardwareDataType.0.machine_name raw -o - - 2>/dev/null
+          )"
+          _starship_chip_type="$(
+            print -rn -- "$_starship_hardware_json" |
+              /usr/bin/plutil -extract SPHardwareDataType.0.chip_type raw -o - - 2>/dev/null
+          )"
+          _starship_platform_uuid="$(
+            print -rn -- "$_starship_hardware_json" |
+              /usr/bin/plutil -extract SPHardwareDataType.0.platform_UUID raw -o - - 2>/dev/null
+          )"
+
+          _starship_machine_name="${(L)_starship_machine_name}"
+          _starship_machine_name="${_starship_machine_name//[^a-z0-9]##/-}"
+          _starship_machine_name="${_starship_machine_name##-}"
+          _starship_machine_name="${_starship_machine_name%%-}"
+
+          _starship_chip_type="${(L)_starship_chip_type}"
+          _starship_chip_type="${_starship_chip_type#apple }"
+          _starship_chip_type="${_starship_chip_type//[^a-z0-9]##/-}"
+          _starship_chip_type="${_starship_chip_type##-}"
+          _starship_chip_type="${_starship_chip_type%%-}"
+
+          if [[ -n "$_starship_machine_name" && -n "$_starship_platform_uuid" ]]; then
+            _starship_machine_hash="$(
+              print -rn -- "$_starship_platform_uuid" | /sbin/md5 -q
+            )"
+            _starship_machine_hash="${_starship_machine_hash[1,6]}"
+            _starship_machine_slug="${_starship_machine_name}"
+            [[ -n "$_starship_chip_type" ]] &&
+              _starship_machine_slug+="-${_starship_chip_type}"
+            _starship_machine_slug+="-${_starship_machine_hash}"
+
+            _starship_machine_cache_tmp="${_starship_machine_cache}.$$"
+            (umask 077; print -r -- "$_starship_machine_slug" >| "$_starship_machine_cache_tmp")
+            mv -f "$_starship_machine_cache_tmp" "$_starship_machine_cache"
+          fi
+          rmdir "${_starship_machine_cache}.lock"
+        ) &!
+      }
+    fi
+  fi
+
+  # Hardware profiling failure or a concurrent first shell: use Zsh's hostname.
+  if [[ -z "$_starship_machine_slug" ]]; then
+    _starship_machine_slug="${(L)HOST%%.*}"
+    _starship_machine_slug="${_starship_machine_slug//[^a-z0-9]##/-}"
+  fi
+
+  export STARSHIP_MACHINE_LABEL="personal:${_starship_machine_slug:-mac}"
+  unset _starship_machine_cache_dir _starship_machine_cache
+  unset _starship_machine_slug _starship_hardware_json
+  unset _starship_machine_name _starship_chip_type _starship_platform_uuid
+  unset _starship_machine_hash _starship_machine_cache_tmp
 fi
 
 # Initialize Starship prompt

--- a/chezmoi/dot_config/zsh/custom.zsh
+++ b/chezmoi/dot_config/zsh/custom.zsh
@@ -74,6 +74,13 @@ export PATH="${(j/:/)path}"
 [[ -f ~/.config/shell/zed.sh ]] && source ~/.config/shell/zed.sh
 [[ -f ~/.config/shell/github.sh ]] && source ~/.config/shell/github.sh
 
+# Detect the work machine once instead of probing from every prompt.
+if [[ -d /Applications/Cisco ]]; then
+  export STARSHIP_MACHINE_KIND="work"
+else
+  unset STARSHIP_MACHINE_KIND
+fi
+
 # Initialize Starship prompt
 eval "$(starship init zsh)"
 


### PR DESCRIPTION
AI-assisted.

- `work:` when Cisco is installed
- otherwise `personal:<model>-<chip>-<id>`
- zero Tailscale/network work in the prompt
- cached read ~0.034 ms; Starship label <1 ms

> [!IMPORTANT]
>
> this eats ~100 ms–3 s once, in the background, the first time it runs. shell doesn't wait.
> afterwards, all subsequent shells use the cache and are fast AF.