### PR TITLE
chore: upgrade Mise-managed developer tools

### DIFF
--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -18,6 +18,9 @@ locked = true
 # Avoid resolving brand-new releases before they have had basic ecosystem soak
 # time. This also applies to supported package-manager backends during install.
 minimum_release_age = "7d"
+# Replace corepack: read the pnpm version from each repo's package.json
+# packageManager field so mise installs and selects it directly.
+idiomatic_version_file_enable_tools = ["pnpm"]
 
 # Machine-global packages remain separate from versioned development tools.
 # mise's built-in Homebrew support can install these without a pre-existing
@@ -74,52 +77,52 @@ run = "MISE_BOOTSTRAP_ACTIVE=1 chezmoi apply --source=\"$HOME/dotfiles/chezmoi\"
 # ============================================================================
 # Core Language Runtimes
 # ============================================================================
-node = "26.5.0"
-python = "3.14.6"
-go = "1.26.5"
+node = "26.7.0"
+python = "3.14.7"
+go = "1.27.0"
 rust = "1.97.1"
 
 # ============================================================================
 # Node.js Tools & Package Managers
 # ============================================================================
-pnpm = "11.13.1"
+pnpm = "11.22.0"
 bun = "1.3.14"
 
 # npm global packages
-"npm:markit-ai" = "0.5.3"
+"npm:markit-ai" = "0.6.1"
 "npm:@nozomioai/nia" = "0.5.2" # Nia CLI only
 "npm:sfw" = "2.0.6"            # Socket Firewall wrapper for package manager network filtering
-"npm:firecrawl-cli" = "1.19.26"
+"npm:firecrawl-cli" = "1.20.0"
 
 # ============================================================================
 # Python CLI Tools from PyPI
 # ============================================================================
-"pipx:parallel-web-tools" = { version = "0.7.1", extras = "cli" }
-"pipx:huggingface_hub" = "1.23.0" # hf CLI
+"pipx:parallel-web-tools" = { version = "0.9.2", extras = "cli" }
+"pipx:huggingface_hub" = "1.28.0" # hf CLI
 
 # ============================================================================
 # Development Tools from Cargo (Rust tools)
 # ============================================================================
-"cargo:eza" = "0.23.4"   # ls replacement
+"cargo:eza" = "0.23.5"   # ls replacement
 "cargo:tokei" = "14.0.0" # code statistics
 
 # ============================================================================
 # Go Tools from GitHub (charmbracelet tools are Go, not Rust)
 # ============================================================================
-"github:charmbracelet/glow" = "2.1.2"
+"github:charmbracelet/glow" = "3.0.0"
 "github:charmbracelet/gum" = "0.17.0"            # shell prompt tool (Go)
-"go:golang.org/x/vuln/cmd/govulncheck" = "1.6.0"
+"go:golang.org/x/vuln/cmd/govulncheck" = "1.7.0"
 
 # ============================================================================
 # Tools from GitHub Releases (Go & other binaries)
 # ============================================================================
 # Chezmoi is installed during the package phase before the bootstrap task.
-"github:rtk-ai/rtk" = "0.28.2"                 # Token-efficient CLI for coding agents
+"github:rtk-ai/rtk" = "0.45.0"                 # Token-efficient CLI for coding agents
 "github:x-motemen/ghq" = "1.10.1"
-"github:cli/cli" = "2.96.0"
-"github:abhinav/git-spice" = "0.31.0"
-"github:RhysSullivan/executor" = "1.5.33"
-"github:vercel-labs/agent-browser" = "0.32.0"
+"github:cli/cli" = "2.97.0"
+"github:abhinav/git-spice" = "0.31.2"
+"github:RhysSullivan/executor" = "1.5.42"
+"github:vercel-labs/agent-browser" = "0.34.0"
 "github:sigoden/projclean" = "0.9.0"          # Project build artifact cleaner
 "github:libkrun/krunkit" = "1.3.2"            # Podman libkrun VM provider
 "aqua:jqlang/jq" = "1.8.2"
@@ -127,28 +130,28 @@ bun = "1.3.14"
 # ============================================================================
 # Tools from Aqua (GitHub releases with verification)
 # ============================================================================
-"aqua:charmbracelet/crush" = "0.85.0"
+"aqua:charmbracelet/crush" = "0.90.0"
 "aqua:sharkdp/bat" = "0.26.1"            # cat replacement with syntax highlighting
 "aqua:dandavison/delta" = "0.19.2"       # git diff viewer
 "aqua:sharkdp/fd" = "10.4.2"             # find replacement
-"aqua:junegunn/fzf" = "0.74.0"
+"aqua:junegunn/fzf" = "0.74.3"
 "aqua:ajeetdsouza/zoxide" = "0.10.0"
-"aqua:dprint/dprint" = "0.55.2"
-"aqua:j178/prek" = "0.4.10"
+"aqua:dprint/dprint" = "0.56.0"
+"aqua:j178/prek" = "0.4.14"
 "aqua:chmln/sd" = "1.1.0"                # sed replacement (simpler syntax)
 "aqua:koalaman/shellcheck" = "0.11.0"    # Shell script static analyzer
-"aqua:mikefarah/yq" = "4.53.3"
+"aqua:mikefarah/yq" = "4.53.4"
 "aqua:terrastruct/d2" = "0.7.1"          # Diagram language
-"aqua:typst/typst" = "0.15.0"
+"aqua:typst/typst" = "0.15.1"
 "aqua:starship/starship" = "1.26.0"
-"aqua:golangci/golangci-lint" = "2.12.2" # Go linter aggregator
-"github:astral-sh/uv" = "0.11.29"
-"aqua:aws/aws-cli" = "2.35.24"
+"aqua:golangci/golangci-lint" = "2.13.0" # Go linter aggregator
+"github:astral-sh/uv" = "0.12.5"
+"aqua:aws/aws-cli" = "2.36.32"
 
 # ============================================================================
 # Tools from npm (Node.js packages)
 # ============================================================================
-"npm:wrangler" = "4.111.0"
+"npm:wrangler" = "4.124.0"
 
 # ============================================================================
 # Notes on Workstation Ownership

--- a/chezmoi/dot_config/mise/mise.lock
+++ b/chezmoi/dot_config/mise/mise.lock
@@ -10,21 +10,21 @@ url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.10.0/zoxide-0.
 url_api = "https://api.github.com/repos/ajeetdsouza/zoxide/releases/assets/466316174"
 
 [[tools."aqua:aws/aws-cli"]]
-version = "2.35.24"
+version = "2.36.32"
 backend = "aqua:aws/aws-cli"
 
 [tools."aqua:aws/aws-cli"."platforms.macos-arm64"]
-checksum = "blake3:b413167c78274265b87c6b439a8990d3781896acd03aef029a39b6c3338745af"
-url = "https://awscli.amazonaws.com/AWSCLIV2-2.35.24.pkg"
+checksum = "blake3:f68b30db35b4e25624959562a3c4230ac2cc94bcd29ba980d71e9976f3e14d3f"
+url = "https://awscli.amazonaws.com/AWSCLIV2-2.36.32.pkg"
 
 [[tools."aqua:charmbracelet/crush"]]
-version = "0.85.0"
+version = "0.90.0"
 backend = "aqua:charmbracelet/crush"
 
 [tools."aqua:charmbracelet/crush"."platforms.macos-arm64"]
-checksum = "sha256:91384d19fc7f446c2d4015605e946df3e833526bacaad299b22d5b72e77f0fdd"
-url = "https://github.com/charmbracelet/crush/releases/download/v0.85.0/crush_0.85.0_Darwin_arm64.tar.gz"
-url_api = "https://api.github.com/repos/charmbracelet/crush/releases/assets/478586430"
+checksum = "sha256:fcd956f05db3e57e8a72de30ad541a8bdc09d711bfba5d3d57bf01926a9933a8"
+url = "https://github.com/charmbracelet/crush/releases/download/v0.90.0/crush_0.90.0_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/charmbracelet/crush/releases/assets/521342103"
 provenance = "cosign"
 
 [[tools."aqua:chmln/sd"]]
@@ -46,50 +46,32 @@ url = "https://github.com/dandavison/delta/releases/download/0.19.2/delta-0.19.2
 url_api = "https://api.github.com/repos/dandavison/delta/releases/assets/383662310"
 
 [[tools."aqua:dprint/dprint"]]
-version = "0.55.2"
+version = "0.56.0"
 backend = "aqua:dprint/dprint"
 
 [tools."aqua:dprint/dprint"."platforms.macos-arm64"]
-checksum = "sha256:e9ba8ed7988f3350501a8cf8af92da616cdec8d9d5c831c069293c587311b49d"
-url = "https://github.com/dprint/dprint/releases/download/0.55.2/dprint-aarch64-apple-darwin.zip"
-url_api = "https://api.github.com/repos/dprint/dprint/releases/assets/477041350"
+checksum = "sha256:79f5c80a3ddebb4717a89a25a79ec1c50947d4cef141df243757925cb47d32e1"
+url = "https://github.com/dprint/dprint/releases/download/0.56.0/dprint-aarch64-apple-darwin.zip"
+url_api = "https://api.github.com/repos/dprint/dprint/releases/assets/519466721"
 
 [[tools."aqua:golangci/golangci-lint"]]
-version = "2.12.2"
+version = "2.13.0"
 backend = "aqua:golangci/golangci-lint"
 
-[tools."aqua:golangci/golangci-lint"."platforms.linux-arm64"]
-provenance = "github-attestations"
-
-[tools."aqua:golangci/golangci-lint"."platforms.linux-arm64-musl"]
-provenance = "github-attestations"
-
-[tools."aqua:golangci/golangci-lint"."platforms.linux-x64"]
-provenance = "github-attestations"
-
-[tools."aqua:golangci/golangci-lint"."platforms.linux-x64-musl"]
-provenance = "github-attestations"
-
 [tools."aqua:golangci/golangci-lint"."platforms.macos-arm64"]
-checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
-provenance = "github-attestations"
-
-[tools."aqua:golangci/golangci-lint"."platforms.macos-x64"]
-provenance = "github-attestations"
-
-[tools."aqua:golangci/golangci-lint"."platforms.windows-x64"]
+checksum = "sha256:72eae670097978e61b78a773a25c27439e35d54094fd986cee5eeeb25d7144fd"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471400"
 provenance = "github-attestations"
 
 [[tools."aqua:j178/prek"]]
-version = "0.4.10"
+version = "0.4.14"
 backend = "aqua:j178/prek"
 
 [tools."aqua:j178/prek"."platforms.macos-arm64"]
-checksum = "sha256:b2be74cd80bc86f679d92ae368d154ce391e4ef9891dc54447976b92df7951f1"
-url = "https://github.com/j178/prek/releases/download/v0.4.10/prek-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/j178/prek/releases/assets/479037973"
+checksum = "sha256:87f7fb2b99871820eb352d9a2327461d25affe354d6d48c4edf3a34f360c6be8"
+url = "https://github.com/j178/prek/releases/download/v0.4.14/prek-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/j178/prek/releases/assets/517620513"
 provenance = "github-attestations"
 
 [[tools."aqua:jqlang/jq"]]
@@ -103,13 +85,13 @@ url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012783"
 provenance = "github-attestations"
 
 [[tools."aqua:junegunn/fzf"]]
-version = "0.74.0"
+version = "0.74.3"
 backend = "aqua:junegunn/fzf"
 
 [tools."aqua:junegunn/fzf"."platforms.macos-arm64"]
-checksum = "sha256:da60e8980e4239a0fc5f1fcfe873f243dfda93a6a13b696b00e1dc8584a77a87"
-url = "https://github.com/junegunn/fzf/releases/download/v0.74.0/fzf-0.74.0-darwin_arm64.tar.gz"
-url_api = "https://api.github.com/repos/junegunn/fzf/releases/assets/468106617"
+checksum = "sha256:1f8501cea4f9c0c2d6110d0ff75d0ec9451cd9d7524d9a26244a154ea89f3bd5"
+url = "https://github.com/junegunn/fzf/releases/download/v0.74.3/fzf-0.74.3-darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/junegunn/fzf/releases/assets/517537091"
 
 [[tools."aqua:koalaman/shellcheck"]]
 version = "0.11.0"
@@ -121,13 +103,13 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056932"
 
 [[tools."aqua:mikefarah/yq"]]
-version = "4.53.3"
+version = "4.53.4"
 backend = "aqua:mikefarah/yq"
 
 [tools."aqua:mikefarah/yq"."platforms.macos-arm64"]
-checksum = "sha256:877de31753a4dd2401aa048937aa9a7fc4d5f6ce858cf31508c5802954297213"
-url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_arm64"
-url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146762"
+checksum = "sha256:e2cf7aa3e7402a25798c4a131a8c38514efdabdc185ca081efd134448aef0428"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.4/yq_darwin_arm64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/520402323"
 provenance = "cosign"
 
 [[tools."aqua:sharkdp/bat"]]
@@ -167,13 +149,13 @@ url = "https://github.com/terrastruct/d2/releases/download/v0.7.1/d2-v0.7.1-maco
 url_api = "https://api.github.com/repos/terrastruct/d2/releases/assets/284023623"
 
 [[tools."aqua:typst/typst"]]
-version = "0.15.0"
+version = "0.15.1"
 backend = "aqua:typst/typst"
 
 [tools."aqua:typst/typst"."platforms.macos-arm64"]
-checksum = "sha256:fe53838737abf93a774495952a1a797b4686e9c4a21c2d99b9fdf77f46cc3572"
-url = "https://github.com/typst/typst/releases/download/v0.15.0/typst-aarch64-apple-darwin.tar.xz"
-url_api = "https://api.github.com/repos/typst/typst/releases/assets/448379808"
+checksum = "sha256:48f62ed034aa3a7978309579ac6ca00045e2ef0da73114e8af27cfd8e74dc05a"
+url = "https://github.com/typst/typst/releases/download/v0.15.1/typst-aarch64-apple-darwin.tar.xz"
+url_api = "https://api.github.com/repos/typst/typst/releases/assets/480299147"
 
 [[tools.bun]]
 version = "1.3.14"
@@ -184,7 +166,7 @@ checksum = "sha256:d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652
 url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-aarch64.zip"
 
 [[tools."cargo:eza"]]
-version = "0.23.4"
+version = "0.23.5"
 backend = "cargo:eza"
 
 [[tools."cargo:tokei"]]
@@ -192,41 +174,41 @@ version = "14.0.0"
 backend = "cargo:tokei"
 
 [[tools."github:RhysSullivan/executor"]]
-version = "1.5.33"
+version = "1.5.42"
 backend = "github:RhysSullivan/executor"
 
 [tools."github:RhysSullivan/executor"."platforms.macos-arm64"]
-checksum = "sha256:3a84494c8df5498035c1e6574793ef779222c0c4d9d4b976c26e09d4869582b0"
-url = "https://github.com/UsefulSoftwareCo/executor/releases/download/v1.5.33/executor-darwin-arm64.zip"
-url_api = "https://api.github.com/repos/UsefulSoftwareCo/executor/releases/assets/474091506"
+checksum = "sha256:16adb72576b01045b348a9bb29fe3daa07c2ebbb0a1727a267f73c17b7e7e699"
+url = "https://github.com/UsefulSoftwareCo/executor/releases/download/v1.5.42/executor-darwin-arm64.zip"
+url_api = "https://api.github.com/repos/UsefulSoftwareCo/executor/releases/assets/519683544"
 
 [[tools."github:abhinav/git-spice"]]
-version = "0.31.0"
+version = "0.31.2"
 backend = "github:abhinav/git-spice"
 
 [tools."github:abhinav/git-spice"."platforms.macos-arm64"]
-checksum = "sha256:b28be2a01f7cb61d66bf65895783ba989d7ffab7424bada9be11657d82b98741"
-url = "https://github.com/abhinav/git-spice/releases/download/v0.31.0/git-spice.Darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/abhinav/git-spice/releases/assets/474949884"
+checksum = "sha256:a2c362d19a818ed1745e7308a40e7eedc57e462eba839fae752e287dbd4057c7"
+url = "https://github.com/abhinav/git-spice/releases/download/v0.31.2/git-spice.Darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/abhinav/git-spice/releases/assets/484895560"
 
 [[tools."github:astral-sh/uv"]]
-version = "0.11.29"
+version = "0.12.5"
 backend = "github:astral-sh/uv"
 
 [tools."github:astral-sh/uv"."platforms.macos-arm64"]
-checksum = "sha256:61c04acc52a33ef0f331e494bdfbedcdb6c26c6970c022ed3699e5860f8930e3"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/astral-sh/uv/releases/assets/478261245"
+checksum = "sha256:5bb0e5fe008a773c3dbcb97ff79cd89e1241464fe9d2f986d52ad8f1b037bd62"
+url = "https://github.com/astral-sh/uv/releases/download/0.12.5/uv-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/uv/releases/assets/514850968"
 provenance = "github-attestations"
 
 [[tools."github:charmbracelet/glow"]]
-version = "2.1.2"
+version = "3.0.0"
 backend = "github:charmbracelet/glow"
 
 [tools."github:charmbracelet/glow"."platforms.macos-arm64"]
-checksum = "sha256:6f7abfb47de69fbf7b0e67d2fa019cc554916e8b6694f9877212be89fc7ebb8c"
-url = "https://github.com/charmbracelet/glow/releases/download/v2.1.2/glow_2.1.2_Darwin_arm64.tar.gz"
-url_api = "https://api.github.com/repos/charmbracelet/glow/releases/assets/392672279"
+checksum = "sha256:4b8a9a32412c0525e4c239e65171706fc5beb6d423608d99fe16788d47b345d3"
+url = "https://github.com/charmbracelet/glow/releases/download/v3.0.0/glow_3.0.0_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/charmbracelet/glow/releases/assets/510466964"
 
 [[tools."github:charmbracelet/gum"]]
 version = "0.17.0"
@@ -268,13 +250,13 @@ url = "https://github.com/charmbracelet/gum/releases/download/v0.17.0/gum_0.17.0
 url_api = "https://api.github.com/repos/charmbracelet/gum/releases/assets/290080922"
 
 [[tools."github:cli/cli"]]
-version = "2.96.0"
+version = "2.97.0"
 backend = "github:cli/cli"
 
 [tools."github:cli/cli"."platforms.macos-arm64"]
-checksum = "sha256:f23a0c37d963aacc3bed703ccbd59b41c5ca22101fab7f00eb2b7cad23aba463"
-url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_macOS_arm64.zip"
-url_api = "https://api.github.com/repos/cli/cli/releases/assets/464728562"
+checksum = "sha256:a58b8fd77b417a38f47a0b54d1370c59b0fcdb324ccc9ca002b0998f7c4c999e"
+url = "https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_macOS_arm64.zip"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/496108298"
 provenance = "github-attestations"
 
 [[tools."github:libkrun/krunkit"]]
@@ -287,13 +269,13 @@ url = "https://github.com/libkrun/krunkit/releases/download/v1.3.2/krunkit-podma
 url_api = "https://api.github.com/repos/libkrun/krunkit/releases/assets/465341860"
 
 [[tools."github:rtk-ai/rtk"]]
-version = "0.28.2"
+version = "0.45.0"
 backend = "github:rtk-ai/rtk"
 
 [tools."github:rtk-ai/rtk"."platforms.macos-arm64"]
-checksum = "sha256:5dede8ac36648960a3ad52611856b9047a7817b755750d2bdbda8d4e9931db4d"
-url = "https://github.com/rtk-ai/rtk/releases/download/v0.28.2/rtk-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/371020972"
+checksum = "sha256:064151cfc2d50b24d810b06a0af2e41b9c945e83534e4c438c3d3eae607fc3f4"
+url = "https://github.com/rtk-ai/rtk/releases/download/v0.45.0/rtk-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/504971576"
 
 [[tools."github:sigoden/projclean"]]
 version = "0.9.0"
@@ -305,13 +287,13 @@ url = "https://github.com/sigoden/projclean/releases/download/v0.9.0/projclean-v
 url_api = "https://api.github.com/repos/sigoden/projclean/releases/assets/414034562"
 
 [[tools."github:vercel-labs/agent-browser"]]
-version = "0.32.0"
+version = "0.34.0"
 backend = "github:vercel-labs/agent-browser"
 
 [tools."github:vercel-labs/agent-browser"."platforms.macos-arm64"]
-checksum = "sha256:c107a3e870096cc70bc5442015d7efa219fa87fb95f1e9c04cd7dadcf4cd0db0"
-url = "https://github.com/vercel-labs/agent-browser/releases/download/v0.32.0/agent-browser-darwin-arm64"
-url_api = "https://api.github.com/repos/vercel-labs/agent-browser/releases/assets/478501136"
+checksum = "sha256:d680a7a96ab86e9ab9d2b571b12919b761e93682ad1de714bbd5ac849c8d7c9c"
+url = "https://github.com/vercel-labs/agent-browser/releases/download/v0.34.0/agent-browser-darwin-arm64"
+url_api = "https://api.github.com/repos/vercel-labs/agent-browser/releases/assets/509430073"
 
 [[tools."github:x-motemen/ghq"]]
 version = "1.10.1"
@@ -323,35 +305,35 @@ url = "https://github.com/x-motemen/ghq/releases/download/v1.10.1/ghq_darwin_arm
 url_api = "https://api.github.com/repos/x-motemen/ghq/releases/assets/394135804"
 
 [[tools.go]]
-version = "1.26.5"
+version = "1.27.0"
 backend = "core:go"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
-url = "https://dl.google.com/go/go1.26.5.darwin-arm64.tar.gz"
+checksum = "sha256:90493b3bbd5e10f91d12153198bf1994fd756399b4fec93b49b0c6e2acdeeb3e"
+url = "https://dl.google.com/go/go1.27.0.darwin-arm64.tar.gz"
 
 [[tools."go:golang.org/x/vuln/cmd/govulncheck"]]
-version = "1.6.0"
+version = "1.7.0"
 backend = "go:golang.org/x/vuln/cmd/govulncheck"
 
 [[tools.node]]
-version = "26.5.0"
+version = "26.7.0"
 backend = "core:node"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:ee920559aaa2391569cff4d737e3b83963430e3a14dedd91bfe0ff53171b5af9"
-url = "https://nodejs.org/dist/v26.5.0/node-v26.5.0-darwin-arm64.tar.gz"
+checksum = "sha256:7ee659a7768e641bbfd5360940660b8e8fd0052f77488f365562bac522fc15d4"
+url = "https://nodejs.org/dist/v26.7.0/node-v26.7.0-darwin-arm64.tar.gz"
 
 [[tools."npm:@nozomioai/nia"]]
 version = "0.5.2"
 backend = "npm:@nozomioai/nia"
 
 [[tools."npm:firecrawl-cli"]]
-version = "1.19.26"
+version = "1.20.0"
 backend = "npm:firecrawl-cli"
 
 [[tools."npm:markit-ai"]]
-version = "0.5.3"
+version = "0.6.1"
 backend = "npm:markit-ai"
 
 [[tools."npm:sfw"]]
@@ -359,37 +341,37 @@ version = "2.0.6"
 backend = "npm:sfw"
 
 [[tools."npm:wrangler"]]
-version = "4.111.0"
+version = "4.124.0"
 backend = "npm:wrangler"
 
 [[tools."pipx:huggingface_hub"]]
-version = "1.23.0"
+version = "1.28.0"
 backend = "pipx:huggingface_hub"
 
 [[tools."pipx:parallel-web-tools"]]
-version = "0.7.1"
+version = "0.9.2"
 backend = "pipx:parallel-web-tools"
 
 [tools."pipx:parallel-web-tools".options]
 extras = "cli"
 
 [[tools.pnpm]]
-version = "11.13.1"
+version = "11.22.0"
 backend = "aqua:pnpm/pnpm"
 
 [tools.pnpm."platforms.macos-arm64"]
-checksum = "sha256:765c2bf04e8129cb58c0f946e324262e418370b35a203b50b1f06a0567ef8bc1"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.13.1/pnpm-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/478563984"
+checksum = "sha256:2000dcc8f0718852c2806ba4dca1edaedf18a4a39264474d5a1c8fcee250adfd"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.22.0/pnpm-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515895947"
 provenance = "github-attestations"
 
 [[tools.python]]
-version = "3.14.6"
+version = "3.14.7"
 backend = "core:python"
 
 [tools.python."platforms.macos-arm64"]
-checksum = "sha256:35d774f61d63c1fd4f1bc9495a7ada92e500dc4382a0df8a9910eb87ea48e8cf"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260623/cpython-3.14.6+20260623-aarch64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:17ecb3d29c49765856370cbb47d948a24ec518be40f607362c1bbb3ebbc5c442"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260825/cpython-3.14.7+20260825-aarch64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [[tools.rust]]


### PR DESCRIPTION
AI-assisted.

- bump 26 Mise-managed runtimes and CLIs while honoring the configured seven-day release-age policy
- enable pnpm idiomatic version-file selection and refresh the macOS ARM64 lock metadata for all 44 configured tools
- prune three stale lock-only tools and 27 obsolete version entries
- validation: the standard updater and prune completed successfully; `mise outdated` reports all tools current for both live and canonical-source configurations; `git diff --check` passes
